### PR TITLE
Allow optional overrides of desiInstall configuration

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,8 @@ Change Log
 ------------------
 
 * Ignore some additional MANIFEST.in warnings.
+* Allow known_products and cross-install configuration to be overridden
+  using an optional configuration file.
 
 1.3.4 (2016-02-22)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -20,7 +20,7 @@ Change Log
 1.3.3 (2016-02-03)
 ------------------
 
-* Added stats module to compute percentiles on distributions.
+* Added :mod:`~desiutil.stats` module to compute percentiles on distributions.
 
 1.3.2 (2016-01-25)
 ------------------
@@ -40,7 +40,7 @@ Change Log
 ------------------
 
 * Updated docstrings for bitmasks.
-* Added :module:`~desuitil.funcfits` module.
+* Added :mod:`~desuitil.funcfits` module.
 
 1.2.0 (2015-11-24)
 ------------------

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -7,6 +7,41 @@ Introduction
 
 This document describes the desiInstall process and the logic behind it.
 
+Configuring desiInstall
+=======================
+
+desiInstall has many options, which are best viewed by typing
+``desiInstall -h``.
+
+In addition, it is possible to override certain internal settings of
+the :class:`~desiutil.install.DesiInstall` object using an
+INI-style configuration file, supplying the name of the file with the
+``--configuration`` option.  Here is an example of the contents of such
+file::
+
+    #
+    # READ ME FIRST
+    #
+    # This file provides an example of how to override certain internal settings
+    # in desiInstall (desiutil.install).  You can copy this file, edit your copy
+    # and supply it to desiInstall with the --configuration option.
+    #
+    #
+    # This section can be used to override built-in names of NERSC hosts.
+    # Specifically, these will override the cross_install_host and
+    # nersc_hosts attributes of the DesiInstall object.
+    #
+    [Cross Install]
+    cross_install_host = cori
+    nersc_hosts = cori,edison,datatran
+    #
+    # This section can be used to append to or override values in the
+    # known_products dictionary in desiutil.install.
+    #
+    [Known Products]
+    my_new_product = https://github.com/me/my_new_product
+    desiutil = https://github.com/you/new_path_to_desiutil
+
 Stages of the Install
 =====================
 

--- a/py/desiutil/funcfits.py
+++ b/py/desiutil/funcfits.py
@@ -9,66 +9,68 @@ Module for fitting simple functions to 1D arrays
 
 J. Xavier Prochaska, UC Santa Cruz
 Fall 2015
-
-.. _desispec: http://desispec.readthedocs.org
 """
-from __future__ import print_function, absolute_import, division, unicode_literals
+from __future__ import (print_function, absolute_import, division,
+                        unicode_literals)
 
 import numpy as np
 import copy
 import warnings
-#import pdb
 
-#
-def func_fit(x,y,func,deg,xmin=None,xmax=None,w=None, **kwargs):
-    """ Simple function fit to 2 arrays
 
-    Modified code originally from Ryan Cooke (PYPIT)
+def func_fit(x, y, func, deg, xmin=None, xmax=None, w=None, **kwargs):
+    """Simple function fit to 2 arrays.
+
+    Modified code originally from Ryan Cooke (PYPIT).
 
     Parameters
     ----------
     x : ndarray
     y : ndarray
     func : str
-      Name of the fitting function:  polynomial, legendre, chebyshev
+        Name of the fitting function:  polynomial, legendre, chebyshev.
     deg : int or dict
-      Order of the fit
+        Order of the fit.
     xmin : float, optional
-      Minimum value in the array (or the left limit for a legendre/chebyshev polynomial)
+        Minimum value in the array (or the left limit for a
+        legendre/chebyshev polynomial).
     xmax : float, optional
-      Maximum value in the array (or the left limit for a legendre/chebyshev polynomial)
+        Maximum value in the array (or the left limit for a
+        legendre/chebyshev polynomial).
     w : ndarray, optional
-      weights to be used in the fitting (weights = 1/sigma)
+        Weights to be used in the fitting (weights = 1/sigma).
 
     Returns
     -------
-    fit_dict : dict
-      dict describing the Fit including the coefficients
+    dict
+        dict describing the Fit including the coefficients.
     """
     # Normalize
     if xmin is None or xmax is None:
         if np.size(x) == 1:
             xmin, xmax = -1.0, 1.0
         else:
-            xmin, xmax = np.min(x), np.max(x)    
+            xmin, xmax = np.min(x), np.max(x)
     xv = 2.0 * (x-xmin)/(xmax-xmin) - 1.0
     # Fit
     if func == "polynomial":
-        fit = np.polynomial.polynomial.polyfit(xv,y,deg,w=w)
+        fit = np.polynomial.polynomial.polyfit(xv, y, deg, w=w)
     elif func == "legendre":
-        fit = np.polynomial.legendre.legfit(xv,y,deg,w=w)
+        fit = np.polynomial.legendre.legfit(xv, y, deg, w=w)
     elif func == "chebyshev":
-        fit = np.polynomial.chebyshev.chebfit(xv,y,deg,w=w)
+        fit = np.polynomial.chebyshev.chebfit(xv, y, deg, w=w)
     else:
         raise ValueError("Fitting function '{0:s}' is not implemented yet".format(func))
-    # Finish    
-    fit_dict = dict(coeff=fit, order=deg, func=func, xmin=xmin, xmax=xmax, **kwargs)
+    # Finish
+    fit_dict = dict(coeff=fit, order=deg, func=func, xmin=xmin, xmax=xmax,
+                    **kwargs)
     return fit_dict
 
-def func_val(x,fit_dict):
-    """ Get values from a fit_dict
 
-    Modified code originally from Ryan Cooke (PYPIT)
+def func_val(x, fit_dict):
+    """Get values from a fit_dict.
+
+    Modified code originally from Ryan Cooke (PYPIT).
 
     Parameters
     ----------
@@ -76,66 +78,72 @@ def func_val(x,fit_dict):
 
     Returns
     -------
-    fit_dict : dict
-      dict describing the Fit including the coefficients
+    ndarray
+        Array containing the values.
     """
     xv = 2.0 * (x-fit_dict['xmin'])/(fit_dict['xmax']-fit_dict['xmin']) - 1.0
     if fit_dict['func'] == "polynomial":
-        return np.polynomial.polynomial.polyval(xv,fit_dict['coeff'])
+        return np.polynomial.polynomial.polyval(xv, fit_dict['coeff'])
     elif fit_dict['func'] == "legendre":
-        return np.polynomial.legendre.legval(xv,fit_dict['coeff'])
+        return np.polynomial.legendre.legval(xv, fit_dict['coeff'])
     elif fit_dict['func'] == "chebyshev":
-        return np.polynomial.chebyshev.chebval(xv,fit_dict['coeff'])
+        return np.polynomial.chebyshev.chebval(xv, fit_dict['coeff'])
     else:
         raise ValueError("Fitting function '{0:s}' is not implemented yet".format(fit_dict['func']))
 
-def iter_fit(xarray, yarray, func, order, weights=None, sigma=None, max_rej=None,  
-    maxone=True, sig_rej=3.0, initialmask=None, forceimask=False, 
-    xmin=None, xmax=None, niter=999, **kwargs):
-    """A "robust" fit with iterative rejection is performed to the xarray, yarray pairs
 
-    Modified code originally from Ryan Cooke (PYPIT)
+def iter_fit(xarray, yarray, func, order, weights=None, sigma=None,
+             max_rej=None, maxone=True, sig_rej=3.0, initialmask=None,
+             forceimask=False, xmin=None, xmax=None, niter=999, **kwargs):
+    """A "robust" fit with iterative rejection is performed to the
+    xarray, yarray pairs.
+
+    Modified code originally from Ryan Cooke (PYPIT).
 
     Parameters
     ----------
     xarray : ndarray
-      independent variable values
+        Independent variable values.
     yarray : ndarray
-      dependent variable values
+        Dependent variable values.
     func : str
-      Name of the fitting function:  polynomial, legendre, chebyshev
+        Name of the fitting function:  polynomial, legendre, chebyshev.
     order : int
-      the order of the function to be used in the fitting
+        The order of the function to be used in the fitting.
     sigma : ndarray, optional
-      Error in the yvalues.  Used only for rejection
+        Error in the yvalues.  Used only for rejection.
     weights : ndarray, optional
-      weights to be used in the fitting (weights = 1/sigma)
+        Weights to be used in the fitting (weights = 1/sigma).
     maxone : bool, optional [True]
-      If True, only the most deviant point in a given iteration will be removed
+        If ``True``, only the most deviant point in a given iteration will
+        be removed.
     sig_rej : float, optional [3.0]
-      confidence interval for rejection 
+        Confidence interval for rejection.
     max_rej : int, optional [None]
-      Maximum number of points to reject
+        Maximum number of points to reject.
     initialmask : ndarray
-       a mask can be supplied as input, these values will be masked for the first iteration. 1 = value masked
+        A mask can be supplied as input, these values will be masked for
+        the first iteration. 1 = value masked.
     forceimask : bool, optional [False]
-      If True, the initialmask will be forced for all iterations
+        If ``True``, the initialmask will be forced for all iterations.
     niter : int, optional [999]
-      Maximum number of iterations 
+        Maximum number of iterations.
     xmin : float
-      minimum value in the array (or the left limit for a legendre/chebyshev polynomial)
+        Minimum value in the array (or the left limit for a
+        legendre/chebyshev polynomial).
     xmax : float
-      maximum value in the array (or the right limit for a legendre/chebyshev polynomial)
+        Maximum value in the array (or the right limit for a
+        legendre/chebyshev polynomial).
 
     Returns
     -------
-    fit_dict, mask
-       fit_dict is a dict containing the fit 
-       mask is an array of the masked values, 
+    tuple
+        The tuple contains a dict containing the fit and a mask array
+        containing masked values.
     """
     # Setup the initial mask
     if initialmask is None:
-        mask = np.zeros(xarray.size,dtype=np.int)
+        mask = np.zeros(xarray.size, dtype=np.int)
         if forceimask:
             warnings.warn("Initial mask cannot be enforced -- no initital mask supplied")
             forceimask = False
@@ -144,8 +152,8 @@ def iter_fit(xarray, yarray, func, order, weights=None, sigma=None, max_rej=None
     # Avoid zero or negative weights
     if weights is not None:
         mask[weights <= 0.] = 1
-    mskcnt=np.sum(mask)
-    imskcnt=copy.copy(mskcnt)
+    mskcnt = np.sum(mask)
+    imskcnt = copy.copy(mskcnt)
     # Iterate, and mask out new values on each iteration
     iiter = 0
     while True:
@@ -154,19 +162,20 @@ def iter_fit(xarray, yarray, func, order, weights=None, sigma=None, max_rej=None
             warnings.warn("Reached maximum number of iterations")
             break
         # Mask
-        w = np.where(mask==0)
+        w = np.where(mask == 0)
         xfit = xarray[w]
         yfit = yarray[w]
         # Fit
-        dfit = func_fit(xfit,yfit,func,order,xmin=xmin,xmax=xmax, **kwargs)
-        yrng = func_val(xarray, dfit) 
+        dfit = func_fit(xfit, yfit, func, order, xmin=xmin, xmax=xmax,
+                        **kwargs)
+        yrng = func_val(xarray, dfit)
         # Reject
         sigmed = 1.4826*np.median(np.abs(yfit-yrng[w]))
         # Check number of parameters
         if xarray.size-np.sum(mask) <= order+2:
             warnings.warn("More parameters than data points - fit might be undesirable")
-            break # More data was masked than allowed by order
-        if maxone: # Only remove the most deviant point
+            break  # More data was masked than allowed by order
+        if maxone:  # Only remove the most deviant point
             if sigma is not None:
                 tst = np.abs(yarray[w]-yrng[w])/sigma[w]
                 m = np.argmax(tst)
@@ -180,24 +189,26 @@ def iter_fit(xarray, yarray, func, order, weights=None, sigma=None, max_rej=None
         else:
             if forceimask:
                 if sigma is not None:
-                    w = np.where((np.abs(yarray-yrng) > sig_rej*sigma) | (initialmask==1))
+                    w = np.where((np.abs(yarray-yrng) > sig_rej*sigma) |
+                                 (initialmask == 1))
                 else:
-                    w = np.where((np.abs(yarray-yrng) > sig_rej*sigmed) | (initialmask==1))
+                    w = np.where((np.abs(yarray-yrng) > sig_rej*sigmed) |
+                                 (initialmask == 1))
             else:
                 if sigma is not None:
                     w = np.where(np.abs(yarray-yrng) > sig_rej*sigma)
                 else:
                     w = np.where(np.abs(yarray-yrng) > sig_rej*sigmed)
             mask[w] = 1
-        if mskcnt == np.sum(mask): break # No new values have been included in the mask
+        if mskcnt == np.sum(mask):
+            break   # No new values have been included in the mask
         if max_rej is not None:
             if mskcnt-imskcnt > max_rej:
                 break
         mskcnt = np.sum(mask)
-        w = np.where(mask==0)
+        w = np.where(mask == 0)
     # Final fit
     xfit = xarray[w]
     yfit = yarray[w]
-    fdict = func_fit(xfit,yfit,func,order,xmin=xmin,xmax=xmax,**kwargs)
+    fdict = func_fit(xfit, yfit, func, order, xmin=xmin, xmax=xmax, **kwargs)
     return fdict, mask
-

--- a/py/desiutil/git.py
+++ b/py/desiutil/git.py
@@ -29,9 +29,8 @@ def last_tag(owner, repo):
     """
     from os.path import basename
     import requests
-    api_url = 'https://api.github.com/repos/{0}/{1}/git/refs/tags/'.format(
-                owner, repo)
-    r = requests.get(api_url)
+    api_url = 'https://api.github.com/repos/{0}/{1}/git/refs/tags/'
+    r = requests.get(api_url.format(owner, repo))
     data = r.json()
     try:
         return basename(data[-1]['ref'])

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -10,6 +10,11 @@ This package contains code for installing DESI software products.
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 # The line above will help with 2to3 support.
+from sys import argv, executable, path, version_info
+try:
+    from setuptools.compat import PY3
+except ImportError:
+    PY3 = version_info >= (3,)
 import requests
 import tarfile
 import logging
@@ -20,13 +25,15 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from ConfigParser import SafeConfigParser
+if PY3:
+    from configparser import SafeConfigParser
+else:
+    from ConfigParser import SafeConfigParser
 from datetime import date
 from types import MethodType
 from os import chdir, environ, getcwd, makedirs, remove, symlink
 from os.path import abspath, basename, exists, isdir, join
 from shutil import copyfile, copytree, rmtree
-from sys import argv, executable, path, version_info
 from .git import last_tag
 from .modules import (init_modules, configure_module,
                       process_module, default_module)

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -964,9 +964,11 @@ class DesiInstall(object):
                                           'cross_install_host'):
                     cross_install_host = self.config.get("Cross Install",
                                                          'cross_install_host')
+                    log.debug("cross_install_host set to {0}.".format(cross_install_host))
                 if self.config.has_option("Cross Install", 'nersc_hosts'):
                     nersc_hosts = self.config.get("Cross Install",
                                                   'nersc_hosts').split(',')
+                    log.debug("nersc_hosts set to {0}.".format(", ".join(nersc_hosts)))
             if self.nersc is None:
                 log.error("Cross-installs are only supported at NERSC.")
             elif self.nersc != cross_install_host:

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -45,7 +45,8 @@ def init_modules(moduleshome=None, method=False):
             execfile(initpy, globals())
             if method:
                 def module_method(self, command, *arguments):
-                    """Wrap the module function provided by the Modules init script.
+                    """Wrap the module function provided by the Modules
+                    init script.
 
                     Parameters
                     ----------
@@ -84,7 +85,8 @@ def init_modules(moduleshome=None, method=False):
                 return module_method
             else:
                 def module_wrapper(command, *arguments):
-                    """Wrap the module function provided by the Modules init script.
+                    """Wrap the module function provided by the Modules
+                    init script.
 
                     Parameters
                     ----------
@@ -220,10 +222,9 @@ def default_module(module_keywords, module_dir):
         The text of the processed .version file.
     """
     from os.path import join
-    dot_version = '#%Module1.0\nset ModulesVersion "{0}"\n'.format(
-                    module_keywords['version'])
+    dot_template = '#%Module1.0\nset ModulesVersion "{version}"\n'
     install_version_file = join(module_dir, module_keywords['name'],
                                 '.version')
     with open(install_version_file, 'w') as v:
-        v.write(dot_version)
+        v.write(dot_template.format(**module_keywords))
     return dot_version

--- a/py/desiutil/setup.py
+++ b/py/desiutil/setup.py
@@ -47,18 +47,15 @@ class DesiModule(Command):
     def finalize_options(self):
         if self.modules is None:
             try:
-                self.modules = join(
-                        '/project/projectdirs/desi/software/modules',
-                        environ['NERSC_HOST'])
+                self.modules = join('/project/projectdirs/desi/software/modules',
+                                    environ['NERSC_HOST'])
             except KeyError:
                 try:
-                    self.modules = join(
-                                    environ['DESI_PRODUCT_ROOT'],
-                                    'modulefiles')
+                    self.modules = join(environ['DESI_PRODUCT_ROOT'],
+                                        'modulefiles')
                 except KeyError:
-                    self.announce(
-                            "Could not determine a Module install directory!",
-                            level=ERROR)
+                    self.announce("Could not determine a Module install directory!",
+                                  level=ERROR)
                     exit(1)
 
     def run(self):
@@ -68,13 +65,12 @@ class DesiModule(Command):
         dev = 'dev' in version
         working_dir = abspath('.')
         module_keywords = configure_module(name, version, dev=dev)
-        module_file = join(working_dir, 'etc', '{0}.module'.format(
-                                   name))
+        module_file = join(working_dir, 'etc', '{0}.module'.format(name))
         if exists(module_file):
             process_module(module_file, module_keywords, self.modules)
         else:
-            self.announce("Could not find a Module file: {}.".format(
-                          module_file), level=ERROR)
+            self.announce("Could not find a Module file: {0}.".format(module_file),
+                          level=ERROR)
         if self.default:
             default_module(module_keywords, self.modules)
         return
@@ -133,10 +129,8 @@ class DesiTest(BaseTest, object):
 
         result = unittest_main(None, None,
                                ([unittest.__file__] + self.test_args),
-                               testLoader=self._resolve_as_ep(
-                                            self.test_loader),
-                               testRunner=self._resolve_as_ep(
-                                            self.test_runner),
+                               testLoader=self._resolve_as_ep(self.test_loader),
+                               testRunner=self._resolve_as_ep(self.test_runner),
                                exit=False)
         if result.result.wasSuccessful():
             if self.coverage:
@@ -203,8 +197,7 @@ def find_version_directory(productname):
     elif isdir(join(setup_dir, productname)):
         version_dir = join(setup_dir, productname)
     else:
-        raise IOError(
-                "Could not find a directory containing version information!")
+        raise IOError("Could not find a directory containing version information!")
     return version_dir
 
 

--- a/py/desiutil/stats.py
+++ b/py/desiutil/stats.py
@@ -9,35 +9,31 @@ Module for fitting simple functions to 1D arrays
 
 J. Xavier Prochaska, UC Santa Cruz
 Fall 2015
-
-.. _desispec: http://desispec.readthedocs.org
 """
-from __future__ import print_function, absolute_import, division, unicode_literals
+from __future__ import (print_function, absolute_import, division,
+                        unicode_literals)
 
 import numpy as np
-#import pdb
 
 
 def perc(x, per=68.2):
-    """ Calculate the percentile bounds of a distribution,
-    i.e. for per=68, the code returns the upper and lower bounds
+    """Calculate the percentile bounds of a distribution,
+    *i.e.* for per=68, the code returns the upper and lower bounds
     that encompass 68percent of the distribution.
 
-    Uses simple interpolation
+    Uses simple interpolation.
 
     Parameters
     ----------
-      x : float
+    x : float
         numpy array of values
-      per : float, optional
+    per : float, optional
         Percentile for the calculation [0-100]
 
     Returns
     -------
-      xper : array
+    array
         Value at lower, value at upper
     """
     #
     return np.percentile(x, [50-per/2.0, 50+per/2.0])
-
-

--- a/py/desiutil/test/t/desiInstall_configuration.ini
+++ b/py/desiutil/test/t/desiInstall_configuration.ini
@@ -1,0 +1,22 @@
+#
+# READ ME FIRST
+#
+# This file provides an example of how to override certain internal settings
+# in desiInstall (desiutil.install).  You can copy this file, edit your copy
+# and supply it to desiInstall with the --configuration option.
+#
+#
+# This section can be used to override built-in names of NERSC hosts.
+# Specifically, these will override the cross_install_host and
+# nersc_hosts attributes of the DesiInstall object.
+#
+[Cross Install]
+cross_install_host = cori
+nersc_hosts = cori,edison,datatran
+#
+# This section can be used to append to or override values in the
+# known_products dictionary in desiutil.install.
+#
+[Known Products]
+my_new_product = https://github.com/me/my_new_product
+# desiutil = https://github.com/you/new_path_to_desiutil

--- a/py/desiutil/test/test_funcfits.py
+++ b/py/desiutil/test/test_funcfits.py
@@ -26,63 +26,63 @@ class TestFuncFits(unittest.TestCase):
     def test_poly_fit(self):
         """Test polynomial fit
         """
-        x = np.linspace(0,np.pi,50)
+        x = np.linspace(0, np.pi, 50)
         y = np.sin(x)
         # Fit
         dfit = func_fit(x, y, 'polynomial', 3)
-        x2 = np.linspace(0,np.pi,100)
-        y2 = func_val(x2,dfit)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.97854984428713754)
 
     def test_legendre_fit(self):
         """Test Legendre fit
         """
         # Generate data
-        x = np.linspace(0,np.pi,50)
+        x = np.linspace(0, np.pi, 50)
         y = np.sin(x)
         # Fit
         dfit = func_fit(x, y, 'legendre', 4)
-        x2 = np.linspace(0,np.pi,100)
-        y2 = func_val(x2,dfit)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99940823486206976)
 
     def test_cheby_fit(self):
         """Test Chebyshev fit
         """
         # Generate data
-        x = np.linspace(0,np.pi,50)
+        x = np.linspace(0, np.pi, 50)
         y = np.sin(x)
         # Fit
         dfit = func_fit(x, y, 'chebyshev', 4)
-        x2 = np.linspace(0,np.pi,100)
-        y2 = func_val(x2,dfit)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99940823486206942)
 
     def test_fit_with_sigma(self):
         """Test fit with sigma
         """
         # Generate data
-        x = np.linspace(0,np.pi,50)
+        x = np.linspace(0, np.pi, 50)
         y = np.sin(x)
         sigy = np.ones_like(y)*0.1
         sigy[::2] = 0.15
         # Fit
         dfit = func_fit(x, y, 'legendre', 4, w=1./sigy)
-        x2 = np.linspace(0,np.pi,100)
-        y2 = func_val(x2,dfit)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99941056289796115)
 
     def test_iterfit(self):
         """Test iter fit with Legendre
         """
         # Generate data
-        x = np.linspace(0,np.pi,100)
+        x = np.linspace(0, np.pi, 100)
         y = np.sin(x)
         #
         y[50] = 3.
         # Fit
         dfit, mask = iter_fit(x, y, 'legendre', 4)
         assert np.sum(mask) == 1
-        x2 = np.linspace(0,np.pi,100)
-        y2 = func_val(x2,dfit)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99941444872371643)

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -86,6 +86,7 @@ class TestInstall(unittest.TestCase):
             environ[key] = env_settings[key]['new']
         default_namespace = Namespace(
             bootstrap=False,
+            config_file='',
             cross_install=False,
             default=False,
             force=False,

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -178,6 +178,15 @@ class TestInstall(unittest.TestCase):
         out = self.desiInstall.get_product_version()
         self.assertEqual(out, (u'https://github.com/desihub/desispec',
                          'desispec', '2.0.0'))
+        options = self.desiInstall.get_options(['--configuration',
+                                                join(self.data_dir,
+                                                     'desiInstall_configuration.ini'),
+                                                'my_new_product', '1.2.3'])
+        out = self.desiInstall.get_product_version()
+        self.assertEqual(out, (u'https://github.com/me/my_new_product',
+                         'my_new_product', '1.2.3'))
+        # Reset the config attribute after testing.
+        self.desiInstall.config = None
 
     def test_identify_branch(self):
         """Test identification of branch installs.

--- a/py/desiutil/test/test_stats.py
+++ b/py/desiutil/test/test_stats.py
@@ -26,7 +26,7 @@ class TestStats(unittest.TestCase):
     def test_perc(self):
         """Test percentile
         """
-        x = np.linspace(0,np.pi,100)
+        x = np.linspace(0, np.pi, 100)
         y = np.sin(x)
         percv = perc(y)
         np.testing.assert_allclose(percv, np.array([0.24316108649289372,


### PR DESCRIPTION
This PR allows certain hard-coded values in desiInstall to be augmented or overridden with an INI-style configuration file.  This fixes #4, and would allow us to quickly adapt the desiInstall configuration without changing the code or cutting a new tag.  For example, this allows

* Adding a new software package to the existing, hard-coded list of known products.
* Changing the list of NERSC hosts for the purposes of cross installing (when new NERSC systems are added or old ones go away).

There are also some code and documentation clean-ups in this PR.