### PR TITLE
Method to 'yamilify' a Python object

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,7 @@ Change Log
 * :mod:`desiutil.stats` module was previously snuck in, but never documented.
 * Minor fixes for desiInstall bootstrap mode.
 * `PR #30`_: Enable use of weights in :func:`~desiutil.funcfits.iter_fit`.
+* Add a method for connverting Python objects to yaml-ready format.  Includes unicode -> str
 
 .. _`PR #30`: https://github.com/desihub/desiutil/pull/30
 

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -1,0 +1,74 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+==================
+desiutils.io
+==================
+
+Module for I/O related code
+"""
+from __future__ import (print_function, absolute_import, division,
+                        unicode_literals)
+import numpy as np
+
+
+def yamlify(obj, debug=False):
+    """ Recursively process an object so it can be serialised for yaml
+    Based on jsonify in linetools
+
+    Note: All keys in dicts are converted to str type
+
+    Parameters
+    ----------
+    obj : any object
+    debug : bool, optional
+
+    Returns
+    -------
+    obj - the same obj is yaml_friendly format
+      (arrays turned to lists, np.int64 converted to int, np.float64 to float,
+      basestring to str, etc.).
+
+    """
+    if isinstance(obj, np.float64):
+        obj = float(obj)
+    elif isinstance(obj, np.float32):
+        obj = float(obj)
+    elif isinstance(obj, np.int32):
+        obj = int(obj)
+    elif isinstance(obj, np.int64):
+        obj = int(obj)
+    elif isinstance(obj, np.int16):
+        obj = int(obj)
+    elif isinstance(obj, np.bool_):
+        obj = bool(obj)
+    elif isinstance(obj, (np.string_,basestring)):
+        obj = str(obj)
+    #elif isinstance(obj, Quantity):
+    #    obj = dict(value=obj.value, unit=obj.unit.to_string())
+    #elif isinstance(obj, np.ndarray):  # Must come after Quantity
+    #    obj = obj.tolist()
+    elif isinstance(obj, dict):
+        # First convert keys
+        obj = {str(key):value for key,value in obj.items()}
+        # Now recursive
+        for key, value in obj.items():
+            obj[key] = yamlify(value, debug=debug)
+    elif isinstance(obj, list):
+        for i,item in enumerate(obj):
+            obj[i] = yamlify(item, debug=debug)
+    elif isinstance(obj, tuple):
+        obj = list(obj)
+        for i,item in enumerate(obj):
+            obj[i] = yamlify(item, debug=debug)
+        obj = tuple(obj)
+    #elif isinstance(obj, Unit):
+    #    obj = obj.name
+    #elif obj is u.dimensionless_unscaled:
+    #    obj = 'dimensionless_unit'
+
+    if debug:
+        print(type(obj))
+    return obj
+
+

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -29,10 +29,9 @@ def yamlify(obj, debug=False):
 
     Returns
     -------
-    obj - the same obj is yaml_friendly format
-      (arrays turned to lists, np.int64 converted to int, np.float64 to float,
-      basestring to str, etc.).
-
+    obj
+       An object suitable for yaml serialization.  For example :class:`numpy.ndarray` is converted to :class:`list`,
+       :class:`numpy.int64` is converted to :class:`int`, etc.
     """
     if isinstance(obj, (np.float64,np.float32)):
         obj = float(obj)
@@ -44,8 +43,8 @@ def yamlify(obj, debug=False):
         obj = str(obj)
     #elif isinstance(obj, Quantity):
     #    obj = dict(value=obj.value, unit=obj.unit.to_string())
-    #elif isinstance(obj, np.ndarray):  # Must come after Quantity
-    #    obj = obj.tolist()
+    elif isinstance(obj, np.ndarray):  # Must come after Quantity
+        obj = obj.tolist()
     elif isinstance(obj, dict):
         # First convert keys
         obj = {str(key):value for key,value in obj.items()}

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -11,6 +11,10 @@ from __future__ import (print_function, absolute_import, division,
                         unicode_literals)
 import numpy as np
 
+try:
+    basestring
+except NameError:  # For Python 3
+    basestring = str
 
 def yamlify(obj, debug=False):
     """ Recursively process an object so it can be serialised for yaml
@@ -30,8 +34,6 @@ def yamlify(obj, debug=False):
       basestring to str, etc.).
 
     """
-    from six import string_types
-
     if isinstance(obj, np.float64):
         obj = float(obj)
     elif isinstance(obj, np.float32):
@@ -44,7 +46,7 @@ def yamlify(obj, debug=False):
         obj = int(obj)
     elif isinstance(obj, np.bool_):
         obj = bool(obj)
-    elif isinstance(obj, (np.string_,string_types)):
+    elif isinstance(obj, (np.string_,basestring)):
         obj = str(obj)
     #elif isinstance(obj, Quantity):
     #    obj = dict(value=obj.value, unit=obj.unit.to_string())

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -30,6 +30,8 @@ def yamlify(obj, debug=False):
       basestring to str, etc.).
 
     """
+    from six import string_types
+
     if isinstance(obj, np.float64):
         obj = float(obj)
     elif isinstance(obj, np.float32):
@@ -42,7 +44,7 @@ def yamlify(obj, debug=False):
         obj = int(obj)
     elif isinstance(obj, np.bool_):
         obj = bool(obj)
-    elif isinstance(obj, (np.string_,basestring)):
+    elif isinstance(obj, (np.string_,string_types)):
         obj = str(obj)
     #elif isinstance(obj, Quantity):
     #    obj = dict(value=obj.value, unit=obj.unit.to_string())

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -34,15 +34,9 @@ def yamlify(obj, debug=False):
       basestring to str, etc.).
 
     """
-    if isinstance(obj, np.float64):
+    if isinstance(obj, (np.float64,np.float32)):
         obj = float(obj)
-    elif isinstance(obj, np.float32):
-        obj = float(obj)
-    elif isinstance(obj, np.int32):
-        obj = int(obj)
-    elif isinstance(obj, np.int64):
-        obj = int(obj)
-    elif isinstance(obj, np.int16):
+    elif isinstance(obj, (np.int32, np.int64, np.int16)):
         obj = int(obj)
     elif isinstance(obj, np.bool_):
         obj = bool(obj)

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 # The line above will help with 2to3 support.
 import unittest
+import sys
 import numpy as np
 from warnings import catch_warnings, simplefilter
 import pdb
@@ -31,7 +32,10 @@ class TestIO(unittest.TestCase):
                      'num2':np.int64(4), 'bool':np.bool(True), 'lst':['tst2', np.int16(2)],
                      'tup':(1,3), 'dct':{'a':'tst3', 'b':np.float32(6.)}}
         assert isinstance(fdict,dict)
-        assert not isinstance(fdict['name'], str)
+        if sys.version_info >= (3,0,0):
+            assert isinstance(fdict['name'], bytes)
+        else:
+            assert isinstance(fdict['name'], unicode)
         assert isinstance(fdict['flt32'], np.float32)
         # Run
         ydict = yamlify(fdict)

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -1,0 +1,41 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.io.
+"""
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+# The line above will help with 2to3 support.
+import unittest
+import numpy as np
+from warnings import catch_warnings, simplefilter
+import pdb
+from ..io import yamlify
+
+
+class TestIO(unittest.TestCase):
+    """Test desiutil.io
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_yamlify(self):
+        """Test yamlify
+        """
+        fdict = {'name':'test', 'num':np.int32(3), 'flt32':np.float32(3.), 'flt64':np.float64(2.),
+                     'num2':np.int64(4), 'bool':np.bool(True), 'lst':['tst2', np.int16(2)],
+                     'tup':(1,3), 'dct':{'a':'tst3', 'b':np.float32(6.)}}
+        assert isinstance(fdict,dict)
+        assert isinstance(fdict['name'], unicode)
+        assert isinstance(fdict['flt32'], np.float32)
+        # Run
+        ydict = yamlify(fdict)
+        assert isinstance(ydict['flt32'], float)
+        for key in ydict.keys():
+            assert isinstance(key,str)
+

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -8,8 +8,7 @@ from __future__ import (absolute_import, division,
 import unittest
 import sys
 import numpy as np
-from warnings import catch_warnings, simplefilter
-import pdb
+#import pdb
 from ..io import yamlify
 
 
@@ -30,16 +29,15 @@ class TestIO(unittest.TestCase):
         """
         fdict = {'name':'test', 'num':np.int32(3), 'flt32':np.float32(3.), 'flt64':np.float64(2.),
                      'num2':np.int64(4), 'bool':np.bool(True), 'lst':['tst2', np.int16(2)],
-                     'tup':(1,3), 'dct':{'a':'tst3', 'b':np.float32(6.)}}
-        assert isinstance(fdict,dict)
+                     'tup':(1,3), 'dct':{'a':'tst3', 'b':np.float32(6.)}, 'array': np.zeros(10)}
         if sys.version_info >= (3,0,0):
-            assert isinstance(fdict['name'], str)
+            self.assertIsInstance(fdict['name'], str)
         else:
-            assert isinstance(fdict['name'], unicode)
-        assert isinstance(fdict['flt32'], np.float32)
+            self.assertIsInstance(fdict['name'], unicode)
         # Run
         ydict = yamlify(fdict)
-        assert isinstance(ydict['flt32'], float)
+        self.assertIsInstance(ydict['flt32'], float)
+        self.assertIsInstance(ydict['array'], list)
         for key in ydict.keys():
-            assert isinstance(key,str)
+            self.assertIsInstance(key, str)
 

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -31,7 +31,7 @@ class TestIO(unittest.TestCase):
                      'num2':np.int64(4), 'bool':np.bool(True), 'lst':['tst2', np.int16(2)],
                      'tup':(1,3), 'dct':{'a':'tst3', 'b':np.float32(6.)}}
         assert isinstance(fdict,dict)
-        assert isinstance(fdict['name'], unicode)
+        assert not isinstance(fdict['name'], str)
         assert isinstance(fdict['flt32'], np.float32)
         # Run
         ydict = yamlify(fdict)

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -33,7 +33,7 @@ class TestIO(unittest.TestCase):
                      'tup':(1,3), 'dct':{'a':'tst3', 'b':np.float32(6.)}}
         assert isinstance(fdict,dict)
         if sys.version_info >= (3,0,0):
-            assert isinstance(fdict['name'], bytes)
+            assert isinstance(fdict['name'], str)
         else:
             assert isinstance(fdict['name'], unicode)
         assert isinstance(fdict['flt32'], np.float32)


### PR DESCRIPTION
Method to convert a Python object (often a dict) into a yaml-valid 
object.  Mainly to be used for writing to yaml.

Am pretty sure this is Python3 compatible (passes Travis and some
of my own tests), but I am not fully confident of all cases.

Creates a new module (io.py)
Updated changes.rst
Added unittest
