### PR TITLE
add desiutil.depend module

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,6 +8,9 @@ desiutil API
 .. automodule:: desiutil.bitmask
     :members:
 
+.. automodule:: desiutil.depend
+    :members:
+
 .. automodule:: desiutil.funcfits
     :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,11 +2,13 @@
 Change Log
 ==========
 
-1.4.2 (unreleased)
+1.5.0 (unreleased)
 ------------------
 
 * Fixed bug affecting people with the C version of Modules installed on
   laptops.
+* Added :mod:`desiutil.depend` tools for manipulating DEPNAMnn and DEPVERnn
+  keywords in FITS headers
 
 1.4.1 (2016-06-07)
 ------------------

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -113,6 +113,19 @@ def hasdep(header, name):
     except KeyError:
         return False
 
+def iterdep(header):
+    '''Returns iterator over (codename, version) tuples'''
+    for i in range(100):
+        namekey = 'DEPNAM{:02d}'.format(i)
+        verkey = 'DEPVER{:02d}'.format(i)
+        if namekey not in header and i==0: continue
+        if namekey in header:
+            yield (header[namekey], header[verkey])
+        else:
+            raise StopIteration
+
+    raise StopIteration
+
 class Dependencies(object):
     """Dictionary-like object to track dependencies.
 
@@ -144,18 +157,9 @@ class Dependencies(object):
 
     def __iter__(self):
         '''Returns iterator over name.'''
-        for i in range(100):
-            namekey = 'DEPNAM{:02d}'.format(i)
-            verkey = 'DEPVER{:02d}'.format(i)
-            if namekey not in self.header and i==0: continue
-            if namekey in self.header:
-                yield self.header[namekey]
-            else:
-                raise StopIteration
-
-        raise StopIteration
+        for name, version in iterdep(self.header):
+            yield name
 
     def items(self):
         '''Returns iterator over (name, version).'''
-        for name in self:
-            yield name, self[name]
+        return iterdep(self.header)

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -1,15 +1,19 @@
-#!/usr/bin/env python
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
 """
+===============
+desiutil.depend
+===============
+
 Utilities for working with code dependencies stored in FITS headers.
 
 The code name and the code version are stored in pairs of keywords, similar
-to how table columns are defined.  e.g.
+to how table columns are defined. *e.g.*::
 
-DEPNAM00 = 'numpy'
-DEPVER00 = '1.11'
-DEPNAM01 = 'desiutil'
-DEPVER01 = '1.4.1'
+    DEPNAM00 = 'numpy'
+    DEPVER00 = '1.11'
+    DEPNAM01 = 'desiutil'
+    DEPVER01 = '1.4.1'
 
 The functions and Dependencies class provided here provide convenience
 wrappers to loop over they keywords looking for a particular dependency
@@ -21,7 +25,7 @@ Examples:
 >>> from desiutil import depend
 >>> import astropy
 >>> from astropy.io import fits
->>> 
+>>>
 >>> hdr = fits.Header()
 >>> depend.setdep(hdr, 'desiutil', desiutil.__version__)
 >>> depend.setdep(hdr, 'astropy', astropy.__version__)
@@ -44,7 +48,7 @@ so that it can be used in subsequent I/O
 >>> codever['foo'] = '3.4'
 >>> for codename, version in codever.items():
 ...     print(codename, version)
-... 
+...
 ('desiutil', '1.4.1.dev316')
 ('astropy', u'1.1.1')
 ('blat', '1.2')
@@ -54,7 +58,7 @@ so that it can be used in subsequent I/O
 
 def setdep(header, name, version):
     '''
-    set dependency version for code name
+    Set dependency version for code name.
 
     Args:
         header : dict-like object to store dependencies
@@ -68,19 +72,17 @@ def setdep(header, name, version):
             if header[namekey] == name:
                 header[verkey] = version
                 return
-            else:
-                continue
-
-        header[namekey] = name
-        header[verkey] = version
-        return
+        else:
+            header[namekey] = name
+            header[verkey] = version
+            return
 
     #- if we got this far, we ran out of numbers
-    raise IndexError
+    raise IndexError("Too many versions to track!")
 
 def getdep(header, name):
     '''
-    get dependency version for code name
+    Get dependency version for code name.
 
     Args:
         header : dict-like object to store dependencies
@@ -88,7 +90,7 @@ def getdep(header, name):
 
     Returns version string for name
 
-    raises KeyError if name not tracked in header
+    Raises KeyError if name not tracked in header
     '''
     for i in range(100):
         namekey = 'DEPNAM{:02d}'.format(i)
@@ -96,8 +98,6 @@ def getdep(header, name):
         if namekey in header:
             if header[namekey] == name:
                 return header[verkey]
-            else:
-                continue
         elif i == 0:
             continue    #- ok if DEPNAM00 is missing; continue to DEPNAME01
         else:
@@ -105,7 +105,7 @@ def getdep(header, name):
 
 def hasdep(header, name):
     '''
-    returns True if version for name is tracked in header, otherwise False
+    Returns ``True`` if version for name is tracked in header, otherwise ``False``.
     '''
     try:
         version = getdep(header, name)
@@ -114,10 +114,19 @@ def hasdep(header, name):
         return False
 
 class Dependencies(object):
+    """Dictionary-like object to track dependencies.
+
+    Parameters
+    ----------
+    header : dict-like, optional
+        A dict-like object.  If not provided, a :class:`~collections.OrderedDict`
+        will be used.
+    """
+
     def __init__(self, header=None):
-        '''Initialize Dependencies with dict-like header object
-        
-        if header is None, use a empty OrderedDict
+        '''Initialize Dependencies with dict-like header object.
+
+        If header is None, use a empty :class:`~collections.OrderedDict`.
         '''
         if header is None:
             from collections import OrderedDict
@@ -126,15 +135,15 @@ class Dependencies(object):
             self.header = header
 
     def __setitem__(self, name, version):
-        '''sets version of name'''
+        '''Sets version of `name`.'''
         setdep(self.header, name, version)
 
     def __getitem__(self, name):
-        '''returns version of name'''
+        '''Returns version of `name`.'''
         return getdep(self.header, name)
 
     def __iter__(self):
-        '''returns iterator over name'''
+        '''Returns iterator over name.'''
         for i in range(100):
             namekey = 'DEPNAM{:02d}'.format(i)
             verkey = 'DEPVER{:02d}'.format(i)
@@ -147,6 +156,6 @@ class Dependencies(object):
         raise StopIteration
 
     def items(self):
-        '''returns iterator over (name, version)'''
+        '''Returns iterator over (name, version).'''
         for name in self:
             yield name, self[name]

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -66,7 +66,7 @@ def setdep(header, name, version):
         verkey = 'DEPVER{:02d}'.format(i)
         if namekey in header:
             if header[namekey] == name:
-                header[namekey] = version
+                header[verkey] = version
                 return
             else:
                 continue

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+"""
+Utilities for working with code dependencies stored in FITS headers.
+
+The code name and the code version are stored in pairs of keywords, similar
+to how table columns are defined.  e.g.
+
+DEPNAM00 = 'numpy'
+DEPVER00 = '1.11'
+DEPNAM01 = 'desiutil'
+DEPVER01 = '1.4.1'
+
+The functions and Dependencies class provided here provide convenience
+wrappers to loop over they keywords looking for a particular dependency
+and adding a new dependency version to next available DEPNAMnn/DEPVERnn.
+
+Examples:
+
+>>> import desiutil
+>>> from desiutil import depend
+>>> import astropy
+>>> from astropy.io import fits
+>>> 
+>>> hdr = fits.Header()
+>>> depend.setdep(hdr, 'desiutil', desiutil.__version__)
+>>> depend.setdep(hdr, 'astropy', astropy.__version__)
+>>> depend.getdep(hdr, 'desiutil')
+'1.4.1.dev316'
+>>> depend.hasdep(hdr, 'astropy')
+True
+>>> hdr
+DEPNAM00= 'desiutil'
+DEPVER00= '1.4.1.dev316'
+DEPNAM01= 'astropy '
+DEPVER01= '1.1.1   '
+
+There is also an object wrapper that gives a header dict-like semantics to
+update or view dependencies.  This directly updates the input header object
+so that it can be used in subsequent I/O
+
+>>> codever = depend.Dependencies(hdr)
+>>> codever['blat'] = '1.2'
+>>> codever['foo'] = '3.4'
+>>> for codename, version in codever.items():
+...     print(codename, version)
+... 
+('desiutil', '1.4.1.dev316')
+('astropy', u'1.1.1')
+('blat', '1.2')
+('foo', '3.4')
+
+"""
+
+def setdep(header, name, version):
+    '''
+    set dependency version for code name
+
+    Args:
+        header : dict-like object to store dependencies
+        name : code name string
+        version : version string
+    '''
+    for i in range(100):
+        namekey = 'DEPNAM{:02d}'.format(i)
+        verkey = 'DEPVER{:02d}'.format(i)
+        if namekey in header:
+            if header[namekey] == name:
+                header[namekey] = version
+                return
+            else:
+                continue
+
+        header[namekey] = name
+        header[verkey] = version
+        return
+
+    #- if we got this far, we ran out of numbers
+    raise IndexError
+
+def getdep(header, name):
+    '''
+    get dependency version for code name
+
+    Args:
+        header : dict-like object to store dependencies
+        name : code name string
+
+    Returns version string for name
+
+    raises KeyError if name not tracked in header
+    '''
+    for i in range(100):
+        namekey = 'DEPNAM{:02d}'.format(i)
+        verkey = 'DEPVER{:02d}'.format(i)
+        if namekey in header:
+            if header[namekey] == name:
+                return header[verkey]
+            else:
+                continue
+        elif i == 0:
+            continue    #- ok if DEPNAM00 is missing; continue to DEPNAME01
+        else:
+            raise KeyError('{} version not found'.format(name))
+
+def hasdep(header, name):
+    '''
+    returns True if version for name is tracked in header, otherwise False
+    '''
+    try:
+        version = getdep(header, name)
+        return True
+    except KeyError:
+        return False
+
+class Dependencies(object):
+    def __init__(self, header=None):
+        '''Initialize Dependencies with dict-like header object
+        
+        if header is None, use a empty OrderedDict
+        '''
+        if header is None:
+            from collections import OrderedDict
+            self.header = OrderedDict()
+        else:
+            self.header = header
+
+    def __setitem__(self, name, version):
+        '''sets version of name'''
+        setdep(self.header, name, version)
+
+    def __getitem__(self, name):
+        '''returns version of name'''
+        return getdep(self.header, name)
+
+    def __iter__(self):
+        '''returns iterator over name'''
+        for i in range(100):
+            namekey = 'DEPNAM{:02d}'.format(i)
+            verkey = 'DEPVER{:02d}'.format(i)
+            if namekey not in self.header and i==0: continue
+            if namekey in self.header:
+                yield self.header[namekey]
+            else:
+                raise StopIteration
+
+        raise StopIteration
+
+    def items(self):
+        '''returns iterator over (name, version)'''
+        for name in self:
+            yield name, self[name]

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -41,9 +41,21 @@ class TestDepend(unittest.TestCase):
         depend.setdep(hdr, 'blat', '1.2.3')
         self.assertEqual(depend.getdep(hdr, 'blat'), '1.2.3')
         self.assertTrue(depend.hasdep(hdr, 'blat'))
+        self.assertFalse(depend.hasdep(hdr, 'zoom'))
         
         with self.assertRaises(KeyError):
             depend.getdep(hdr, 'foo')
+
+    def test_update(self):
+        hdr = dict()
+        depend.setdep(hdr, 'blat', '1.0')
+        self.assertEqual(depend.getdep(hdr, 'blat'), '1.0')
+        depend.setdep(hdr, 'blat', '2.0')
+        self.assertEqual(depend.getdep(hdr, 'blat'), '2.0')
+        self.assertNotIn('DEPNAM01', hdr)
+        depend.setdep(hdr, 'foo', '3.0')
+        self.assertEqual(hdr['DEPNAM01'], 'foo')
+        self.assertEqual(hdr['DEPVER01'], '3.0')
 
     def test_class(self):
         hdr = dict()

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.git.
+"""
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+import unittest
+from desiutil import depend
+
+try:
+    from astropy.io import fits
+    test_fits_header = True
+except ImportError:
+    test_fits_header = False
+
+class TestDepend(unittest.TestCase):
+    """Test desiutil.depend
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_functions(self):
+        hdr = dict()
+        depend.setdep(hdr, 'blat', '1.2.3')
+        self.assertEqual(depend.getdep(hdr, 'blat'), '1.2.3')
+        self.assertTrue(depend.hasdep(hdr, 'blat'))
+        
+        with self.assertRaises(KeyError):
+            depend.getdep(hdr, 'foo')
+            
+    @unittest.skipUnless(test_fits_header, 'requires astropy.io.fits')
+    def test_fits_header(self):
+        hdr = fits.Header()
+        depend.setdep(hdr, 'blat', '1.2.3')
+        self.assertEqual(depend.getdep(hdr, 'blat'), '1.2.3')
+        self.assertTrue(depend.hasdep(hdr, 'blat'))
+        
+        with self.assertRaises(KeyError):
+            depend.getdep(hdr, 'foo')
+
+    def test_class(self):
+        hdr = dict()
+        x = depend.Dependencies(hdr)
+        x['blat'] = '1.2.3'
+        x['foo'] = '0.1'
+        self.assertEqual(x['blat'], hdr['DEPVER00'])
+        self.assertEqual(x['foo'], hdr['DEPVER01'])
+        for name, version in x.items():
+            self.assertEqual(version, x[name])
+            
+        for name in x:
+            self.assertEqual(x[name], depend.getdep(hdr, name))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division,
 
 import unittest
 from collections import OrderedDict
-from ..depend import setdep, getdep, hasdep, Dependencies
+from ..depend import setdep, getdep, hasdep, iterdep, Dependencies
 
 try:
     from astropy.io import fits
@@ -105,6 +105,23 @@ class TestDepend(unittest.TestCase):
         self.assertEqual(hdr['DEPNAM01'], 'foo')
         self.assertEqual(hdr['DEPVER01'], '3.0')
 
+    def test_iter(self):
+        """Test iteration methods.
+        """
+        hdr = dict()
+        for i in range(100):
+            hdr["DEPNAM{0:02d}".format(i)] = "test{0:03d}".format(i)
+            hdr["DEPVER{0:02d}".format(i)] = "v{0:d}.0.1".format(i)
+        y = Dependencies(hdr)
+        for name in y:
+            self.assertEqual(y[name], getdep(hdr, name))
+
+        for name, version in y.items():
+            self.assertEqual(version, getdep(hdr, name))
+
+        for name, version in iterdep(hdr):
+            self.assertEqual(version, getdep(hdr, name))
+
     def test_class(self):
         """Test the Dependencies object.
         """
@@ -122,13 +139,6 @@ class TestDepend(unittest.TestCase):
         for name in x:
             self.assertEqual(x[name], getdep(hdr, name))
 
-        hdr = dict()
-        for i in range(100):
-            hdr["DEPNAM{0:02d}".format(i)] = "test{0:03d}".format(i)
-            hdr["DEPVER{0:02d}".format(i)] = "v{0:d}.0.1".format(i)
-        y = Dependencies(hdr)
-        for name in y:
-            self.assertEqual(y[name], getdep(hdr, name))
 
 
 if __name__ == '__main__':

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -1,12 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-"""Test desiutil.git.
+"""Test desiutil.depend.
 """
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
 import unittest
-from desiutil import depend
+from collections import OrderedDict
+from ..depend import setdep, getdep, hasdep, Dependencies
 
 try:
     from astropy.io import fits
@@ -26,49 +27,109 @@ class TestDepend(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
-    def test_functions(self):
+    def test_setdep(self):
+        """Test function that sets dependency keywords.
+        """
         hdr = dict()
-        depend.setdep(hdr, 'blat', '1.2.3')
-        self.assertEqual(depend.getdep(hdr, 'blat'), '1.2.3')
-        self.assertTrue(depend.hasdep(hdr, 'blat'))
-        
+        setdep(hdr, 'blat', '1.2.3')
+        self.assertEqual(hdr['DEPNAM00'], 'blat')
+        self.assertEqual(hdr['DEPVER00'], '1.2.3')
+        setdep(hdr, 'foo', '2.3.4')
+        self.assertEqual(hdr['DEPNAM01'], 'foo')
+        self.assertEqual(hdr['DEPVER01'], '2.3.4')
+        setdep(hdr, 'blat', '3.4.5')
+        self.assertEqual(hdr['DEPNAM00'], 'blat')
+        self.assertEqual(hdr['DEPVER00'], '3.4.5')
+        setdep(hdr, 'bar', '7.8.9')
+        setdep(hdr, 'baz', '9.8.7')
+        setdep(hdr, 'foo', '4.3.2')
+        self.assertEqual(hdr['DEPNAM01'], 'foo')
+        self.assertEqual(hdr['DEPVER01'], '4.3.2')
+        hdr = dict()
+        with self.assertRaises(IndexError):
+            for i in range(101):
+                setdep(hdr, 'test{0:03d}'.format(i), "v{0:d}.0.1".format(i))
+
+    def test_getdep(self):
+        """Test function that gets dependency values.
+        """
+        hdr = dict()
+        for i in range(10):
+            setdep(hdr, 'test{0:03d}'.format(i), "v{0:d}.0.1".format(i))
+        self.assertEqual(hdr['DEPNAM00'], 'test000')
+        self.assertEqual(hdr['DEPVER00'], 'v0.0.1')
+        self.assertEqual(getdep(hdr, 'test005'), 'v5.0.1')
+        hdr = dict()
+        for i in range(10):
+            hdr["DEPNAM{0:02d}".format(i+1)] = "test{0:03d}".format(i+1)
+            hdr["DEPVER{0:02d}".format(i+1)] = "v{0:d}.0.1".format(i+1)
+        self.assertEqual(getdep(hdr, 'test005'), 'v5.0.1')
         with self.assertRaises(KeyError):
-            depend.getdep(hdr, 'foo')
-            
+            foo = getdep(hdr, 'test100')
+
+    def test_hasdep(self):
+        """Test function that checks for the existence of a dependency.
+        """
+        hdr = dict()
+        for i in range(10):
+            hdr["DEPNAM{0:02d}".format(i+1)] = "test{0:03d}".format(i+1)
+            hdr["DEPVER{0:02d}".format(i+1)] = "v{0:d}.0.1".format(i+1)
+        self.assertTrue(hasdep(hdr, 'test001'))
+        self.assertTrue(hasdep(hdr, 'test010'))
+        self.assertFalse(hasdep(hdr, 'test020'))
+
     @unittest.skipUnless(test_fits_header, 'requires astropy.io.fits')
     def test_fits_header(self):
+        """Test dependency functions with an actual FITS header.
+        """
         hdr = fits.Header()
-        depend.setdep(hdr, 'blat', '1.2.3')
-        self.assertEqual(depend.getdep(hdr, 'blat'), '1.2.3')
-        self.assertTrue(depend.hasdep(hdr, 'blat'))
-        self.assertFalse(depend.hasdep(hdr, 'zoom'))
-        
+        setdep(hdr, 'blat', '1.2.3')
+        self.assertEqual(getdep(hdr, 'blat'), '1.2.3')
+        self.assertTrue(hasdep(hdr, 'blat'))
+        self.assertFalse(hasdep(hdr, 'zoom'))
+        setdep(hdr, 'blat', '1.5')
+        self.assertEqual(getdep(hdr, 'blat'), '1.5')
+        self.assertTrue(hasdep(hdr, 'blat'))
+
         with self.assertRaises(KeyError):
-            depend.getdep(hdr, 'foo')
+            getdep(hdr, 'foo')
 
     def test_update(self):
         hdr = dict()
-        depend.setdep(hdr, 'blat', '1.0')
-        self.assertEqual(depend.getdep(hdr, 'blat'), '1.0')
-        depend.setdep(hdr, 'blat', '2.0')
-        self.assertEqual(depend.getdep(hdr, 'blat'), '2.0')
+        setdep(hdr, 'blat', '1.0')
+        self.assertEqual(getdep(hdr, 'blat'), '1.0')
+        setdep(hdr, 'blat', '2.0')
+        self.assertEqual(getdep(hdr, 'blat'), '2.0')
         self.assertNotIn('DEPNAM01', hdr)
-        depend.setdep(hdr, 'foo', '3.0')
+        setdep(hdr, 'foo', '3.0')
         self.assertEqual(hdr['DEPNAM01'], 'foo')
         self.assertEqual(hdr['DEPVER01'], '3.0')
 
     def test_class(self):
+        """Test the Dependencies object.
+        """
+        d = Dependencies()
+        self.assertTrue(isinstance(d.header, OrderedDict))
         hdr = dict()
-        x = depend.Dependencies(hdr)
+        x = Dependencies(hdr)
         x['blat'] = '1.2.3'
         x['foo'] = '0.1'
         self.assertEqual(x['blat'], hdr['DEPVER00'])
         self.assertEqual(x['foo'], hdr['DEPVER01'])
         for name, version in x.items():
             self.assertEqual(version, x[name])
-            
+
         for name in x:
-            self.assertEqual(x[name], depend.getdep(hdr, name))
+            self.assertEqual(x[name], getdep(hdr, name))
+
+        hdr = dict()
+        for i in range(100):
+            hdr["DEPNAM{0:02d}".format(i)] = "test{0:03d}".format(i)
+            hdr["DEPVER{0:02d}".format(i)] = "v{0:d}.0.1".format(i)
+        y = Dependencies(hdr)
+        for name in y:
+            self.assertEqual(y[name], getdep(hdr, name))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds a `desiutil.depend` module with utilities for working with code dependencies stored in FITS headers.  The code name and the code version are stored in pairs of keywords, similar to how table columns are defined.  e.g.
```
DEPNAM00 = 'numpy'
DEPVER00 = '1.11'
DEPNAM01 = 'desiutil'
DEPVER01 = '1.4.1'
```
The functions and Dependencies class provide convenience wrappers to loop over they keywords looking for a particular dependency and adding a new dependency version to next available DEPNAMnn/DEPVERnn.

Examples:
```
>>> import desiutil
>>> from desiutil import depend
>>> import astropy
>>> from astropy.io import fits
>>> 
>>> hdr = fits.Header()
>>> depend.setdep(hdr, 'desiutil', desiutil.__version__)
>>> depend.setdep(hdr, 'astropy', astropy.__version__)
>>> depend.getdep(hdr, 'desiutil')
'1.4.1.dev316'
>>> depend.hasdep(hdr, 'astropy')
True
>>> hdr
DEPNAM00= 'desiutil'
DEPVER00= '1.4.1.dev316'
DEPNAM01= 'astropy '
DEPVER01= '1.1.1   '
```
There is also an object wrapper that gives a header dict-like semantics to update or view dependencies.  This directly updates the input header object so that it can be used in subsequent I/O
```
>>> codever = depend.Dependencies(hdr)
>>> codever['blat'] = '1.2'
>>> codever['foo'] = '3.4'
>>> for codename, version in codever.items():
...     print(codename, version)
... 
('desiutil', '1.4.1.dev316')
('astropy', u'1.1.1')
('blat', '1.2')
('foo', '3.4')
```

This includes tests and an update to changes.rst .  After this is merged I'd like to tag 1.5.0 so that this can be used in desispec.