### PR TITLE
add add_dependencies()

### DIFF
--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -15,8 +15,8 @@ to how table columns are defined. *e.g.*::
     DEPNAM01 = 'desiutil'
     DEPVER01 = '1.4.1'
 
-The functions and Dependencies class provided here provide convenience
-wrappers to loop over they keywords looking for a particular dependency
+The functions and Dependencies class provide convenience wrappers
+to loop over they keywords looking for a particular dependency
 and adding a new dependency version to next available DEPNAMnn/DEPVERnn.
 
 Examples:
@@ -125,6 +125,48 @@ def iterdep(header):
             raise StopIteration
 
     raise StopIteration
+
+def add_dependencies(header, module_names=None):
+    '''Adds DEPNAMnn, DEPVERnn keywords to header for imported modules
+    
+    Args:
+        header : dict-like object, e.g. astropy.io.fits.Header
+    
+    Options:
+        module_names : list of module names to check
+            if None, check a list of known potential DESI dependencies
+        
+    Only adds the dependency keywords if the module has already been
+    previously loaded in this python session.  Uses module.__version__
+    if available, otherwise "unknown (/path/to/module/)".
+    '''
+    import sys
+    import importlib
+    
+    setdep(header, 'python', sys.version.replace('\n', ' '))
+    
+    if module_names is None:
+        module_names = [
+            'numpy', 'scipy', 'astropy', 'yaml', 'matplotlib',
+            'requests', 'fitsio', 'h5py', 'mpi4py', 'psycopg2',
+            'desiutil', 'desispec', 'desitarget', 'desimodel', 'desisim',
+            'redmonster',
+            'specter', 'speclite', 'specsim',
+            ]
+        
+
+    #- Set version strings only for modules that have already been loaded
+    for module in module_names:
+        if module in sys.modules:
+            #- already loaded, but we need a reference to the module object
+            x = importlib.import_module(module)
+            try:
+                version = x.__version__
+            except AttributeError:
+                #- e.g. redmonster doesn't set __version__
+                version = 'unknown ({})'.format(x.__path__[0])
+                
+            setdep(header, module, version)
 
 class Dependencies(object):
     """Dictionary-like object to track dependencies.

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -7,7 +7,8 @@ from __future__ import (absolute_import, division,
 
 import unittest
 from collections import OrderedDict
-from ..depend import setdep, getdep, hasdep, iterdep, Dependencies
+from ..depend import setdep, getdep, hasdep, iterdep
+from ..depend import Dependencies, add_dependencies
 
 try:
     from astropy.io import fits
@@ -139,6 +140,20 @@ class TestDepend(unittest.TestCase):
         for name in x:
             self.assertEqual(x[name], getdep(hdr, name))
 
+    def test_add_dependencies(self):
+        """Test add_dependencies function."""
+        import desiutil
+        hdr = OrderedDict()
+        add_dependencies(hdr)
+        self.assertEqual(getdep(hdr, 'desiutil'), desiutil.__version__)
+        import numpy
+        add_dependencies(hdr)
+        self.assertEqual(getdep(hdr, 'numpy'), numpy.__version__)
+        #- ok, but no action
+        add_dependencies(hdr, ['blatbar', 'quatlarm'])
+        self.assertFalse(hasdep(hdr, 'blatbar'))
+        self.assertFalse(hasdep(hdr, 'quatlarm'))
+        
 
 
 if __name__ == '__main__':

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -154,6 +154,13 @@ class TestDepend(unittest.TestCase):
         self.assertFalse(hasdep(hdr, 'blatbar'))
         self.assertFalse(hasdep(hdr, 'quatlarm'))
         
+        #- no .__version__
+        add_dependencies(hdr, ['os.path', 'sys'])
+        self.assertTrue(hasdep(hdr, 'os.path'))
+        self.assertTrue(getdep(hdr, 'os.path').startswith('unknown'))
+        self.assertTrue(hasdep(hdr, 'sys'))
+        self.assertTrue(getdep(hdr, 'sys').startswith('unknown'))
+        
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds `desiutil.depend.add_dependencies(header, module_names=None)` function that will loop over known possible DESI dependencies and add them to the header only if they have already been imported by the code.  This assumes that if the module is loaded, it was loaded for a good reason and should be listed as a dependency.  Conversely, if a module wasn't loaded by the time you got far enough to write a file then it wasn't actually a dependency for that file.  This saves individual packages or I/O routines from having to maintain their own list of what might have been a dependency.  `module_names` allows the user to override with a different list of module names to check.  This does not go so far as trying to automagically detect every loaded module that isn't part of the standard library.

The intension is that every `io.write*` function in `desisim`, `desispec`, and `desitarget` should call this to update the primary HDU header before writing it out.

The current list of modules checked is:
```
        module_names = [
            'numpy', 'scipy', 'astropy', 'yaml', 'matplotlib',
            'requests', 'fitsio', 'h5py', 'mpi4py', 'psycopg2',
            'desiutil', 'desispec', 'desitarget', 'desimodel', 'desisim',
            'redmonster',
            'specter', 'speclite', 'specsim',
            ]
```
Some of these are not yet dependencies but might be in the future; the "is it loaded" check is easy and fast and is ok if the module isn't even installed, so we can err on the side of future completeness.

Are there others that should be included?