### PR TITLE
Encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
             - dvipng
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
 env:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,11 @@
 Change Log
 ==========
 
-1.7.1 (unreleased)
+1.8.0 (unreleased)
 ------------------
 
-* No changes yet
+* Added :func:`~desiutil.io.encode_table` and :func:`~desiutil.io.decode_table`
+  for converting string columns in tables between unicode and bytes (PR #41).
 
 1.7.0 (2016-08-18)
 ------------------

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -115,6 +115,31 @@ def _dtype_size(dtype):
     i = dtype.str.find(dtype.kind)
     return int(dtype.str[i+1:])
 
+def _pick_encoding(table, encoding):
+    '''
+    pick which encoding to use; giving warning if options are in conflict
+
+    Args:
+        table : astropy Table object
+        encoding : (str) encoding to use; None to use table.meta['ENCODING']
+
+    Note: `encoding` trumps `table.meta['ENCODING']`
+    '''
+    if encoding is None:
+        if 'ENCODING' in table.meta:
+            encoding = table.meta['ENCODING']
+        else:
+            raise UnicodeError('No encoding given as argument or in table metadata')
+    elif 'ENCODING' in table.meta and table.meta['ENCODING'] != encoding:
+        import warnings
+        message = """\
+data.metadata['ENCODING']=='{}' does not match option '{}';
+use encoding=None to use data.metadata['ENCODING'] instead""".format(\
+            table.meta['ENCODING'], encoding)
+        warnings.warn(message)
+
+    return encoding
+
 def encode_table(data, encoding='ascii'):
     '''
     Encode unicode strings in a table into bytes using numpy.char.encode
@@ -135,24 +160,19 @@ def encode_table(data, encoding='ascii'):
         UnicodeError if no encoding is given as argument or in table metadata
 
     Note: `encoding` option overides data.meta['ENCODING'];
-        use encoding=None to use data.meta['ENCODING']
+        use encoding=None to use data.meta['ENCODING'] instead
     '''
     from astropy.table import Table
     import numpy as np
     table = Table(data, copy=False)
-
-    if encoding is None:
-        if 'ENCODING' in table.meta:
-            encoding = table.meta['ENCODING']
-        else:
-            raise UnicodeError('No encoding given as argument or in table')
+    encoding = _pick_encoding(table, encoding)
 
     for col in table.colnames:
         dtype = table[col].dtype
         if dtype.kind == 'U':
             Sn = 'S{}'.format(_dtype_size(dtype))
             table.replace_column(col, np.char.encode(table[col], encoding=encoding).astype(Sn))
-            # table.replace_column(col, np.char.encode(table[col], encoding=encoding))
+
     table.meta['ENCODING'] = encoding
     return table
 
@@ -164,9 +184,13 @@ def decode_table(data, encoding='ascii', native=True):
         data : numpy structured array or astropy Table
 
     Options:
-        encoding : encoding to use for converting bytes into unicode
+        encoding : encoding to use for converting bytes into unicode;
+            default 'ascii'; if None, try ENCODING keyword in data instead
         native : if True (default), only decode if native str type is unicode
             (i.e. python3 but not python2)
+
+    Note: `encoding` option overides data.meta['ENCODING'];
+        use encoding=None to use data.meta['ENCODING'] instead
     '''
     from astropy.table import Table
     import numpy as np
@@ -176,16 +200,12 @@ def decode_table(data, encoding='ascii', native=True):
     if native and np.str_('a').dtype.kind == 'S':
         return table
 
-    if encoding is None:
-        if 'ENCODING' in table.meta:
-            encoding = table.meta['ENCODING']
-        else:
-            raise UnicodeError('No encoding given as argument or in table')
-
+    encoding = _pick_encoding(table, encoding)
     for col in table.colnames:
         dtype = table[col].dtype
         if dtype.kind == 'S':
             Un = 'U{}'.format(_dtype_size(dtype))
             table.replace_column(col, np.char.decode(table[col], encoding=encoding).astype(Un))
 
+    table.meta['ENCODING'] = encoding
     return table

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -113,8 +113,7 @@ def _dtype_size(dtype):
     Note that this is different from dtype.itemsize, which is number of bytes
     '''
     i = dtype.str.find(dtype.kind)
-    n = int(dtype.str[i+1:])
-    return int(n)
+    return int(dtype.str[i+1:])
 
 def encode_table(data, encoding='ascii'):
     '''

--- a/py/desiutil/io.py
+++ b/py/desiutil/io.py
@@ -164,7 +164,12 @@ def encode_table(data, encoding='ascii'):
     '''
     from astropy.table import Table
     import numpy as np
-    table = Table(data, copy=False)
+
+    try:
+        table = Table(data, copy=False)
+    except ValueError:  #- https://github.com/astropy/astropy/issues/5298
+        table = Table(data, copy=True)
+
     encoding = _pick_encoding(table, encoding)
 
     for col in table.colnames:
@@ -194,7 +199,10 @@ def decode_table(data, encoding='ascii', native=True):
     '''
     from astropy.table import Table
     import numpy as np
-    table = Table(data, copy=False)
+    try:
+        table = Table(data, copy=False)
+    except ValueError:  #- https://github.com/astropy/astropy/issues/5298
+        table = Table(data, copy=True)
 
     #- Check if native str type is bytes
     if native and np.str_('a').dtype.kind == 'S':

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -88,6 +88,22 @@ class TestIO(unittest.TestCase):
         tx = io.decode_table(data, native=True)
         self.assertIsInstance(tx['x'][0], str)
 
+        #- Test roundtype with 2D array and unsigned ints
+        data = np.zeros(4, dtype=[(str('x'), ('U8', 3)), (str('y'), 'u8')])
+        data['y'] = np.arange(len(data))
+        data['x'][0] = ['a', 'bb', 'c']
+        data['x'][1] = ['x', 'yy', 'z']
+        t1 = io.encode_table(data)
+        self.assertEqual(t1['x'].dtype.kind, 'S')
+        self.assertEqual(t1['y'].dtype.kind, data['y'].dtype.kind)
+        self.assertTrue(np.all(t1['y'] == data['y']))
+        t2 = io.decode_table(t1, native=False)
+        self.assertEqual(t2['x'].dtype.kind, 'U')
+        self.assertEqual(t2['x'].dtype, data['x'].dtype)
+        self.assertEqual(t2['y'].dtype.kind, data['y'].dtype.kind)
+        self.assertTrue(np.all(t2['x'] == data['x']))
+        self.assertTrue(np.all(t2['y'] == data['y']))        
+
     def test_yamlify(self):
         """Test yamlify
         """

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -10,7 +10,7 @@ import sys
 import numpy as np
 from astropy.table import Table
 #import pdb
-from desiutil import io
+import desiutil.io
 
 try:
     basestring
@@ -34,11 +34,11 @@ class TestIO(unittest.TestCase):
         data = np.zeros(4, dtype=[(str('x'), 'U4'), (str('y'), 'f8')])
         data['x'] = 'ab'  #- purposefully have fewer characters than width
         data['y'] = np.arange(len(data))
-        t1 = io.encode_table(data)
+        t1 = desiutil.io.encode_table(data)
         self.assertEqual(t1['x'].dtype.kind, 'S')
         self.assertEqual(t1['y'].dtype.kind, data['y'].dtype.kind)
         self.assertTrue(np.all(t1['y'] == data['y']))
-        t2 = io.decode_table(t1, native=False)
+        t2 = desiutil.io.decode_table(t1, native=False)
         self.assertEqual(t2['x'].dtype.kind, 'U')
         self.assertEqual(t2['x'].dtype, data['x'].dtype)
         self.assertEqual(t2['y'].dtype.kind, data['y'].dtype.kind)
@@ -47,22 +47,22 @@ class TestIO(unittest.TestCase):
 
         #- have to give an encoding
         with self.assertRaises(UnicodeError):
-            tx = io.encode_table(data, encoding=None)
+            tx = desiutil.io.encode_table(data, encoding=None)
 
         del t1.meta['ENCODING']
         with self.assertRaises(UnicodeError):
-            tx = io.decode_table(t1, encoding=None, native=False)
+            tx = desiutil.io.decode_table(t1, encoding=None, native=False)
 
         #- Test encoding / decoding round-trip with Table
         data = Table()
         data['x'] = np.asarray(['a', 'bb', 'ccc'], dtype='U')
         data['y'] = np.arange(len(data['x']))
 
-        t1 = io.encode_table(data)
+        t1 = desiutil.io.encode_table(data)
         self.assertEqual(t1['x'].dtype.kind, 'S')
         self.assertEqual(t1['y'].dtype.kind, data['y'].dtype.kind)
         self.assertTrue(np.all(t1['y'] == data['y']))
-        t2 = io.decode_table(t1, native=False)
+        t2 = desiutil.io.decode_table(t1, native=False)
         self.assertEqual(t2['x'].dtype.kind, 'U')
         self.assertEqual(t2['y'].dtype.kind, data['y'].dtype.kind)
         self.assertTrue(np.all(t2['x'] == data['x']))
@@ -70,22 +70,22 @@ class TestIO(unittest.TestCase):
 
         #- Non-default encoding with non-ascii unicode
         data['x'][0] = 'µ'
-        t1 = io.encode_table(data, encoding='utf-8')
+        t1 = desiutil.io.encode_table(data, encoding='utf-8')
         self.assertEqual(t1.meta['ENCODING'], 'utf-8')
-        t2 = io.decode_table(t1, encoding=None, native=False)
+        t2 = desiutil.io.decode_table(t1, encoding=None, native=False)
         self.assertEqual(t2.meta['ENCODING'], 'utf-8')
         self.assertTrue(np.all(t2['x'] == data['x']))
         with self.assertRaises(UnicodeEncodeError):
-            tx = io.encode_table(data, encoding='ascii')
+            tx = desiutil.io.encode_table(data, encoding='ascii')
         with self.assertRaises(UnicodeDecodeError):
-            tx = io.decode_table(t1, encoding='ascii', native=False)
+            tx = desiutil.io.decode_table(t1, encoding='ascii', native=False)
 
         #- native=True should retain native str type
         data = Table()
         data['x'] = np.asarray(['a', 'bb', 'ccc'], dtype='S')
         data['y'] = np.arange(len(data['x']))
         native_str_kind = np.str_('a').dtype.kind
-        tx = io.decode_table(data, native=True)
+        tx = desiutil.io.decode_table(data, native=True)
         self.assertIsInstance(tx['x'][0], str)
 
         #- Test roundtype with 2D array and unsigned ints
@@ -93,11 +93,11 @@ class TestIO(unittest.TestCase):
         data['y'] = np.arange(len(data))
         data['x'][0] = ['a', 'bb', 'c']
         data['x'][1] = ['x', 'yy', 'z']
-        t1 = io.encode_table(data)
+        t1 = desiutil.io.encode_table(data)
         self.assertEqual(t1['x'].dtype.kind, 'S')
         self.assertEqual(t1['y'].dtype.kind, data['y'].dtype.kind)
         self.assertTrue(np.all(t1['y'] == data['y']))
-        t2 = io.decode_table(t1, native=False)
+        t2 = desiutil.io.decode_table(t1, native=False)
         self.assertEqual(t2['x'].dtype.kind, 'U')
         self.assertEqual(t2['x'].dtype, data['x'].dtype)
         self.assertEqual(t2['y'].dtype.kind, data['y'].dtype.kind)
@@ -115,7 +115,7 @@ class TestIO(unittest.TestCase):
         else:
             self.assertIsInstance(fdict['name'], unicode)
         # Run
-        ydict = io.yamlify(fdict)
+        ydict = desiutil.io.yamlify(fdict)
         self.assertIsInstance(ydict['flt32'], float)
         self.assertIsInstance(ydict['array'], list)
         for key in ydict.keys():
@@ -128,7 +128,7 @@ class TestIO(unittest.TestCase):
         # Merge two dicts with a common key
         dict1 = {'a': {'b':2, 'c': 3}}
         dict2 = {'a': {'d': 4}}
-        dict3 = io.combine_dicts(dict1, dict2)
+        dict3 = desiutil.io.combine_dicts(dict1, dict2)
         self.assertEqual(dict3, {'a': {'b':2, 'c':3, 'd':4}})
         # Shouldn't modify originals
         self.assertEqual(dict1, {'a': {'b':2, 'c': 3}})
@@ -136,7 +136,7 @@ class TestIO(unittest.TestCase):
         # Merge two dicts with different keys
         dict1 = {'a': 2}
         dict2 = {'b': 4}
-        dict3 = io.combine_dicts(dict1, dict2)
+        dict3 = desiutil.io.combine_dicts(dict1, dict2)
         self.assertEqual(dict3, {'a':2, 'b':4})
         self.assertEqual(dict1, {'a': 2})
         self.assertEqual(dict2, {'b': 4})
@@ -144,18 +144,18 @@ class TestIO(unittest.TestCase):
         dict1 = {'a': 2}
         dict2 = {'a': 4}
         with self.assertRaises(ValueError):
-            dict3 = io.combine_dicts(dict1, dict2)
+            dict3 = desiutil.io.combine_dicts(dict1, dict2)
         # Overlapping leafs with a scalar/dict mix raise an error
         dict1 = {'a': {'b':3}}
         dict2 = {'a': {'b':2, 'c': 3}}
         with self.assertRaises(ValueError):
-            io.combine_dicts(dict1, dict2)
+            desiutil.io.combine_dicts(dict1, dict2)
         with self.assertRaises(ValueError):
-            io.combine_dicts(dict2, dict1)
+            desiutil.io.combine_dicts(dict2, dict1)
         # Deep merge
         dict1 = {'a': {'b': {'x':1, 'y':2}}}
         dict2 = {'a': {'b': {'p':3, 'q':4}}}
-        dict3 = io.combine_dicts(dict1, dict2)
+        dict3 = desiutil.io.combine_dicts(dict1, dict2)
         self.assertEqual(dict3, {'a': {'b': {'x':1, 'y':2, 'p':3, 'q':4}}})
         self.assertEqual(dict1, {'a': {'b': {'x':1, 'y':2}}})
         self.assertEqual(dict2, {'a': {'b': {'p':3, 'q':4}}})

--- a/py/desiutil/test/test_io.py
+++ b/py/desiutil/test/test_io.py
@@ -80,6 +80,20 @@ class TestIO(unittest.TestCase):
         with self.assertRaises(UnicodeDecodeError):
             tx = desiutil.io.decode_table(t1, encoding='ascii', native=False)
 
+        #- Table can specify encoding if option encoding=None
+        data['x'][0] = 'p'
+        data.meta['ENCODING'] = 'utf-8'
+        t1 = desiutil.io.encode_table(data, encoding=None)
+        self.assertEqual(t1.meta['ENCODING'], 'utf-8')
+        t2 = desiutil.io.decode_table(t1, native=False, encoding=None)
+        self.assertEqual(t2.meta['ENCODING'], 'utf-8')
+
+        #- conflicting encodings print warning but still proceed
+        t1 = desiutil.io.encode_table(data, encoding='ascii')
+        self.assertEqual(t1.meta['ENCODING'], 'ascii')
+        t2 = desiutil.io.decode_table(t1, encoding='utf-8', native=False)
+        self.assertEqual(t2.meta['ENCODING'], 'utf-8')
+
         #- native=True should retain native str type
         data = Table()
         data['x'] = np.asarray(['a', 'bb', 'ccc'], dtype='S')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ setuptools
 requests
 pyyaml
 matplotlib
+astropy


### PR DESCRIPTION
This PR adds `desiutil.io.encode_table()` and `decode_table()` to convert table columns between unicode and bytes, useful for converting python 3 strings into bytes prior to writing out to FITS of HDF5.  `decode_table` includes the option to decode to the native python string type, i.e. decode for python 3 but not for python 2.

`encode_table` will be needed for desihub/desispec#266 .  We don't actually need `decode_table` yet because `astropy.io.fits` and `astropy.table.Table` try to do that for you, but it could come in handy if we switch to using fitsio or h5py.

This does introduce a dependence upon astropy, which is new but I think OK.  I put this into requirements.txt so that (hopefully) travis tests will install that.  In the code, astropy is only imported if `encode_table` or `decode_table` are actually called.  There may be a better way to install it for tests without foisting it upon everyone via requirements.txt; @weaverba137 can comment if this should be done differently.