### PR TITLE
Python directory

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 1.9.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Allow top-level ``/python`` directories to be detected (not just ``/py``)
+  to support redmonster_.
+
+.. _redmonster: https://github.com/desihub/redmonster
 
 1.9.0 (2016-10-12)
 ------------------

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -208,7 +208,7 @@ def configure_module(product, version, product_root, working_dir=None, dev=False
     if isdir(join(working_dir, 'python')):
         if dev:
             module_keywords['needs_trunk_py'] = ''
-            module-keywrods['trunk_py_dir'] = '/python'
+            module_keywords['trunk_py_dir'] = '/python'
         else:
             module_keywords['needs_python'] = ''
     if exists(join(working_dir, 'setup.cfg')):

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -205,6 +205,12 @@ def configure_module(product, version, product_root, working_dir=None, dev=False
             module_keywords['needs_trunk_py'] = ''
         else:
             module_keywords['needs_python'] = ''
+    if isdir(join(working_dir, 'python')):
+        if dev:
+            module_keywords['needs_trunk_py'] = ''
+            module-keywrods['trunk_py_dir'] = '/python'
+        else:
+            module_keywords['needs_python'] = ''
     if exists(join(working_dir, 'setup.cfg')):
         conf = SafeConfigParser()
         conf.read([join(working_dir, 'setup.cfg')])


### PR DESCRIPTION
This PR fixes #46 by searching for a top-level `/python` directory.