### PR TITLE
enable installation of new desihub repos

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -26,6 +26,9 @@ desiutil API
 .. automodule:: desiutil.modules
     :members:
 
+.. automodule:: desiutil.plots
+    :members:
+
 .. automodule:: desiutil.setup
     :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,11 @@ Change Log
 1.9.2 (unreleased)
 ------------------
 
-* enables desiInstall of desihub packages even if they aren't in the
-  known_products list yet
+* Enables desiInstall of desihub_ packages even if they aren't in the
+  ``desiutil.install.known_products`` list yet.
+* Include :mod:`desiutil.plots` in documentation.
+
+.. _desihub: https://github.com/desihub
 
 1.9.1 (2016-10-17)
 ------------------
@@ -41,8 +44,8 @@ Change Log
 1.7.0 (2016-08-18)
 ------------------
 
-* Added combineDicts method
-* Added plots.py module including plot_slices
+* Added :func:`~desiutil.io.combine_dicts` function.
+* Added :mod:`desiutil.plots` module including :func:`~desiutil.plots.plot_slices`.
 
 1.6.0 (2016-07-01)
 ------------------
@@ -57,7 +60,7 @@ Change Log
 * Fixed bug affecting people with the C version of Modules installed on
   laptops.
 * Added :mod:`desiutil.depend` tools for manipulating DEPNAMnn and DEPVERnn
-  keywords in FITS headers
+  keywords in FITS headers.
 
 1.4.1 (2016-06-07)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ Change Log
 1.9.2 (unreleased)
 ------------------
 
-* No changes yet.
+* enables desiInstall of desihub packages even if they aren't in the
+  known_products list yet
 
 1.9.1 (2016-10-17)
 ------------------

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -377,6 +377,8 @@ class DesiInstall(object):
                 self.baseproduct = self.options.product
                 log.warning('guessing {0} is at {1}'.format(
                     self.baseproduct, self.fullproduct))
+                log.warning('Add location to desiutil.install.known_products '+
+                            'if that is incorrect')
         self.baseversion = basename(self.options.product_version)
         self.github = False
         if 'github.com' in self.fullproduct:

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -372,10 +372,11 @@ class DesiInstall(object):
                 self.fullproduct = known_products[self.options.product]
                 self.baseproduct = self.options.product
             except KeyError:
-                message = ("Could not determine the exact location of " +
-                           "{0}!").format(self.options.product)
-                log.critical(message)
-                raise DesiInstallException(message)
+                self.fullproduct = 'https://github.com/desihub/{}'.format(
+                        self.options.product)
+                self.baseproduct = self.options.product
+                log.warning('guessing {0} is at {1}'.format(
+                    self.baseproduct, self.fullproduct))
         self.baseversion = basename(self.options.product_version)
         self.github = False
         if 'github.com' in self.fullproduct:

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -366,19 +366,17 @@ class DesiInstall(object):
                     known_products[name] = value
         if '/' in self.options.product:
             self.baseproduct = basename(self.options.product)
-            self.fullproduct = known_products[self.baseproduct]
         else:
-            try:
-                self.fullproduct = known_products[self.options.product]
-                self.baseproduct = self.options.product
-            except KeyError:
-                self.fullproduct = 'https://github.com/desihub/{}'.format(
-                        self.options.product)
-                self.baseproduct = self.options.product
-                log.warning('guessing {0} is at {1}'.format(
-                    self.baseproduct, self.fullproduct))
-                log.warning('Add location to desiutil.install.known_products '+
-                            'if that is incorrect')
+            self.baseproduct = self.options.product
+        try:
+            self.fullproduct = known_products[self.baseproduct]
+        except KeyError:
+            self.fullproduct = 'https://github.com/desihub/{}'.format(
+                    self.baseproduct)
+            log.warning('Guessing {0} is at {1}.'.format(
+                self.baseproduct, self.fullproduct))
+            log.warning('Add location to desiutil.install.known_products '+
+                        'if that is incorrect.')
         self.baseversion = basename(self.options.product_version)
         self.github = False
         if 'github.com' in self.fullproduct:

--- a/py/desiutil/plots.py
+++ b/py/desiutil/plots.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 """
-============
+===============
 desiutils.plots
-============
+===============
 
 Module for code plots.
 """
@@ -27,31 +27,36 @@ def plot_slices(x, y, x_lo, x_hi, y_cut, num_slices=5, min_count=100, axis=None,
 
     Parameters
     ----------
-    x : array of float
+    x : array of :class:`float`
         X-coordinates to scatter plot.  Points outside [x_lo, x_hi] are
         not displayed.
-    y : array of float
+    y : array of :class:`float`
         Y-coordinates to scatter plot.  Y values are assumed to be roughly
         symmetric about zero.
-    x_lo : float
-        Minimum value of x to plot.
-    x_hi : float
-        Maximum value of x to plot.
-    y_cut : float
-        The target maximum value of |y|.  A dashed line at this value is
-        added to the plot, and the vertical axis is clipped at
-        |y| = 1.25 * y_cut (but values outside this range are included in
-        the percentile statistics).
-    num_slices : int
+    x_lo : :class:`float`
+        Minimum value of `x` to plot.
+    x_hi : :class:`float`
+        Maximum value of `x` to plot.
+    y_cut : :class:`float`
+        The target maximum value of :math:`|y|`.  A dashed line at this value
+        is added to the plot, and the vertical axis is clipped at
+        :math:`|y|` = 1.25 * `y_cut` (but values outside this range are
+        included in the percentile statistics).
+    num_slices : :class:`int`, optional
         Number of equally spaced slices to divide the interval [x_lo, x_hi]
         into.
-    min_count : int
+    min_count : :class:`int`, optional
         Do not use slices with fewer points for superimposed percentile
         statistics.
-    axis : matplotlib axis object or None
-        Uses the current axis if this is None.
-    set_ylim_from_stats : bool, optional
-        Set ylim of plot from 95% stat
+    axis : :class:`matplotlib.axes.Axes`, optional
+        Uses the current axis if this is not set.
+    set_ylim_from_stats : :class:`bool`, optional
+        Set ylim of plot from 95% stat.
+
+    Returns
+    -------
+    :class:`matplotlib.axes.Axes`
+        The Axes object used in the plot.
     """
     import matplotlib.pyplot as plt
 

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -166,10 +166,9 @@ class TestInstall(unittest.TestCase):
         """Test resolution of product/version input.
         """
         options = self.desiInstall.get_options(['foo', 'bar'])
-        with self.assertRaises(DesiInstallException) as cm:
-            out = self.desiInstall.get_product_version()
-        self.assertEqual(str(cm.exception),
-                         "Could not determine the exact location of foo!")
+        out = self.desiInstall.get_product_version()
+        self.assertEqual(out, (u'https://github.com/desihub/foo',
+                         'foo', 'bar'))
         options = self.desiInstall.get_options(['desiutil', '1.0.0'])
         out = self.desiInstall.get_product_version()
         self.assertEqual(out, (u'https://github.com/desihub/desiutil',


### PR DESCRIPTION
This PR enables desiInstall to install repos in desihub even if they aren't previously added to the known_products list.  e.g. successfully installing the new surveysim repo:
```
desi@edison01[1020]$ desiInstall surveysim 0.1.1
desiInstall [desiutil.install.DesiInstall.get_options] Log - WARNING: The environment variable LANG is not set!
desiInstall [desiutil.install.DesiInstall.get_product_version] Log - WARNING: guessing surveysim is at https://github.com/desihub/surveysim
desiInstall [desiutil.install.DesiInstall.get_product_version] Log - WARNING: Add location to desiutil.install.known_products if that is incorrect
desi@edison01[1023]$ module avail surveysim

--------------------------------------------------------- /global/common/edison/contrib/desi/modulefiles ---------------------------------------------------------
surveysim/0.1.1
```

If the product isn't actually under https://github.com/desihub, the subsequent crash is still informative enough to be obvious what happened and what to do:
```
desi@edison01[1022]$ desiInstall blatfoo 1.2.3  
desiInstall [desiutil.install.DesiInstall.get_options] Log - WARNING: The environment variable LANG is not set!
desiInstall [desiutil.install.DesiInstall.get_product_version] Log - WARNING: guessing blatfoo is at https://github.com/desihub/blatfoo
desiInstall [desiutil.install.DesiInstall.get_product_version] Log - WARNING: Add location to desiutil.install.known_products if that is incorrect
desiInstall [desiutil.install.DesiInstall.verify_url] Log - CRITICAL: Error 404 querying GitHub URL: https://github.com/desihub/blatfoo/archive/1.2.3.tar.gz.
```
