### PR TITLE
add new sklearn.GaussianMixtureModel functionality

### DIFF
--- a/py/desiutil/sklearn.py
+++ b/py/desiutil/sklearn.py
@@ -1,0 +1,72 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+================
+desiutil.sklearn
+================
+
+Useful functions from the sklearn python package.
+"""
+from __future__ import (print_function, absolute_import, division,
+                        unicode_literals)
+
+class GaussianMixtureModel(object):
+    """Read and sample from a pre-defined Gaussian mixture model.
+
+    """
+    def __init__(self, weights, means, covars, covtype):
+        self.weights = weights
+        self.means = means
+        self.covars = covars
+        self.covtype = covtype
+        self.n_components, self.n_dimensions = self.means.shape
+
+    @staticmethod
+    def save(model, filename):
+        from astropy.io import fits
+        hdus = fits.HDUList()
+        hdr = fits.Header()
+        hdr['covtype'] = model.covariance_type
+        hdus.append(fits.ImageHDU(model.weights_, name='weights', header=hdr))
+        hdus.append(fits.ImageHDU(model.means_, name='means'))
+        hdus.append(fits.ImageHDU(model.covars_, name='covars'))
+        hdus.writeto(filename, clobber=True)
+
+    @staticmethod
+    def load(filename):
+        from astropy.io import fits
+        hdus = fits.open(filename, memmap=False)
+        hdr = hdus[0].header
+        covtype = hdr['covtype']
+        model = GaussianMixtureModel(
+            hdus['weights'].data, hdus['means'].data, hdus['covars'].data, covtype)
+        hdus.close()
+        return model
+
+    def sample(self, n_samples=1, random_state=None):
+
+        if self.covtype != 'full':
+            return NotImplementedError(
+                'covariance type "{0}" not implemented yet.'.format(self.covtype))
+
+        # Code adapted from sklearn's GMM.sample()
+        if random_state is None:
+            random_state = np.random.RandomState()
+
+        weight_cdf = np.cumsum(self.weights)
+        X = np.empty((n_samples, self.n_dimensions))
+        rand = random_state.rand(n_samples)
+        # decide which component to use for each sample
+        comps = weight_cdf.searchsorted(rand)
+        # for each component, generate all needed samples
+        for comp in range(self.n_components):
+            # occurrences of current component in X
+            comp_in_X = (comp == comps)
+            # number of those occurrences
+            num_comp_in_X = comp_in_X.sum()
+            if num_comp_in_X > 0:
+                X[comp_in_X] = random_state.multivariate_normal(
+                    self.means[comp], self.covars[comp], num_comp_in_X)
+        return X
+
+ 

--- a/py/desiutil/sklearn.py
+++ b/py/desiutil/sklearn.py
@@ -44,6 +44,7 @@ class GaussianMixtureModel(object):
         return model
 
     def sample(self, n_samples=1, random_state=None):
+        import numpy as np
 
         if self.covtype != 'full':
             return NotImplementedError(


### PR DESCRIPTION
This PR adds a new module semi-arbitrarily called ```sklearn``` which contains the ```GaussianMixtureModel``` class taken from sklearn.  This class was previously in ```desisim.templates``` but now it is needed by both the template-generating code *and* ```desitarget.mock.io``` (as part of https://github.com/desihub/desitarget/issues/136; see also https://github.com/desihub/desitarget/issues/106 and [dr2_mag_distributions.ipynb](https://github.com/desihub/desitarget/blob/master/doc/dr2_mag_distributions.ipynb).

I called it sklearn in case we decide to pull in other functionality without introducing an unnecessary dependence but we can easily change the name.

[Thanks to @dkirkby, who originally pulled this piece out of sklearn.]