### PR TITLE
Travis 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
 
         # Coverage test, pass the results to coveralls.
         - os: linux
-          python: 3.5
+          python: 2.7
           env: MAIN_CMD='coverage' SETUP_CMD='run py/desiutil/test/desiutil_test_suite.py'
 
         # PEP 8 compliance.

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ addons:
             - dvipng
 python:
     - 2.7
-    - 3.4
     - 3.5
+    - 3.6
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -34,6 +34,8 @@ env:
         # to repeat them for all configurations.
         - MAIN_CMD='python setup.py'
     matrix:
+        - SETUP_CMD='egg_info'
+        - SETUP_CMD='bdist_egg'
         - SETUP_CMD='test'
 
 matrix:
@@ -48,24 +50,18 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
         - os: linux
-          python: 2.7
+          python: 3.5
           env: SETUP_CMD='build_sphinx'
           # -w is an astropy extension
 
-        # Do a bdist_egg compile.  This will catch things like errors in the
-        # overall package structure.
-        - os: linux
-          python: 2.7
-          env: SETUP_CMD='bdist_egg'
-
         # Coverage test, pass the results to coveralls.
         - os: linux
-          python: 2.7
+          python: 3.5
           env: MAIN_CMD='coverage' SETUP_CMD='run py/desiutil/test/desiutil_test_suite.py'
 
         # PEP 8 compliance.
 #         - os: linux
-#           python: 2.7
+#           python: 3.5
 #           env: MAIN_CMD='pep8' SETUP_CMD='--count py/desiutil'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,13 @@ matrix:
           # -w is an astropy extension
 
         # Coverage test, pass the results to coveralls.
+        # - os: linux
+        #   python: 2.7
+        #   env: MAIN_CMD='coverage' SETUP_CMD='run py/desiutil/test/desiutil_test_suite.py'
+
         - os: linux
-          python: 2.7
-          env: MAIN_CMD='coverage' SETUP_CMD='run py/desiutil/test/desiutil_test_suite.py'
+          python: 3.5
+          env: MAIN_CMD='coverage' SETUP_CMD='run --source=desiutil setup.py test'
 
         # PEP 8 compliance.
 #         - os: linux

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ Change Log
 ------------------
 
 * Get .travis.yml file and other components ready for Python 3.6.
+* Increase test coverage in a few areas.
 
 1.9.3 (2017-03-01)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Change Log
 1.9.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Get .travis.yml file and other components ready for Python 3.6.
 
 1.9.3 (2017-03-01)
 ------------------

--- a/py/desiutil/test/test_log.py
+++ b/py/desiutil/test/test_log.py
@@ -35,6 +35,31 @@ class TestLog(unittest.TestCase):
             logger.error("This is an error message.")
             logger.critical("This is a critical error message.")
 
+    def test_log_with_desi_loglevel(self):
+        """Test basic logging functionality with DESI_LOGLEVEL set.
+        """
+        from os import environ
+        desi_level_cache = self.desi_level
+        for lvl in ('warning', 'foobar'):
+            self.desi_level = environ['DESI_LOGLEVEL'] = lvl
+            for level in (None, l.DEBUG, l.INFO, l.WARNING, l.ERROR):
+                logger = l.get_logger(level)
+                print("With the requested debugging level={0}:".format(level))
+                if self.desi_level is not None and (self.desi_level != "" ):
+                    print("    (but overuled by env. DESI_LOGLEVEL='{0}')".format(self.desi_level))
+                print("--------------------------------------------------")
+                logger.debug("This is a debugging message.")
+                logger.info("This is an informational message.")
+                logger.warning("This is a warning message.")
+                logger.error("This is an error message.")
+                logger.critical("This is a critical error message.")
+        if desi_level_cache is None:
+            del environ['DESI_LOGLEVEL']
+            self.desi_level = None
+        else:
+            environ['DESI_LOGLEVEL'] = desi_level_cache
+            self.desi_level = desi_level_cache
+
     def test_log_with_timestamp(self):
         """Test logging with timestamps.
         """

--- a/py/desiutil/test/test_plots.py
+++ b/py/desiutil/test/test_plots.py
@@ -10,7 +10,7 @@ import shutil, tempfile
 import os
 import numpy as np
 import sys
-#Set non-interactive backend for Travis
+# Set non-interactive backend for Travis
 import matplotlib
 matplotlib.use('agg')
 
@@ -21,18 +21,25 @@ try:
 except NameError:  # For Python 3
     basestring = str
 
+try:
+    import mpl_toolkits.basemap
+    have_basemap = True
+except ImportError:
+    have_basemap = False
+
 class TestPlots(unittest.TestCase):
     """Test desiutil.plots
     """
 
     @classmethod
-    def setUpClass(self):
-        self.test_dir = tempfile.mkdtemp()
-        self.plot_file = os.path.join(self.test_dir,'test_slices.png')
-        self.plot_file2 = os.path.join(self.test_dir,'test_sky.png')
+    def setUpClass(cls):
+        cls.test_dir = tempfile.mkdtemp()
+        cls.plot_file = os.path.join(cls.test_dir, 'test_slices.png')
+        cls.plot_file2 = os.path.join(cls.test_dir, 'test_sky.png')
+
     @classmethod
-    def tearDownClass(self):
-        shutil.rmtree(self.test_dir)
+    def tearDownClass(cls):
+        shutil.rmtree(cls.test_dir)
 
     def test_slices(self):
         """Test plot_slices
@@ -47,12 +54,8 @@ class TestPlots(unittest.TestCase):
         ax_slices.set_xlabel('x')
         if 'TRAVIS_JOB_ID' not in os.environ:
             plt.savefig(self.plot_file)
-    try:
-        import mpl_toolkits.basemap
-        have_basemap = True
-    except ImportError:
-        have_basemap = False
-    @unittest.skipIf(have_basemap == False, 'Skipping tests of plot_sky that require basemap to be installed first')
+
+    @unittest.skipIf(not have_basemap, 'Skipping tests of plot_sky that require basemap to be installed first')
     def test_plot_sky(self):
         """Test plot_sky
         """
@@ -63,6 +66,7 @@ class TestPlots(unittest.TestCase):
         ax = plot_sky_binned(ra, dec)
         if 'TRAVIS_JOB_ID' not in os.environ:
             plt.savefig(self.plot_file2)
+
 
 def test_suite():
     """Allows testing of only this module with the command::

--- a/py/desiutil/test/test_sklearn.py
+++ b/py/desiutil/test/test_sklearn.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.sklearn.
+"""
+from __future__ import absolute_import, print_function
+import unittest
+from ..sklearn import GaussianMixtureModel
+
+
+class TestSKLearn(unittest.TestCase):
+    """Test desispec.sklearn
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
This PR:

1. Demonstrates how to run `coverage` in Python 3.5.  In many cases we are still running coverage tests in 2.7.
2. Runs the Travis `build_sphinx` test in Python 3.5.
3. Adds Python 3.6 tests to the .travis.yml file, because we might as well get ready for that.
4. Increases test coverage on some modules.

Item 1 is the most important, but in general, this is pretty non-controversial stuff. I will merge within 24 hours, unless there are specific requests for reviews.