### PR TITLE
fix install test at NERSC

### DIFF
--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -329,12 +329,13 @@ class TestInstall(unittest.TestCase):
         except KeyError:
             old_root = None
         environ['NERSC_HOST'] = 'edison'
-        options = self.desiInstall.get_options(['desiutil', 'master'])
+        test_code_version = 'test-blat-foo'
+        options = self.desiInstall.get_options(['desiutil', test_code_version])
         self.desiInstall.get_product_version()
         install_dir = self.desiInstall.set_install_dir()
         self.assertEqual(install_dir, join(
                          self.desiInstall.default_nersc_dir['edison'], 'code',
-                         'desiutil', 'master'))
+                         'desiutil', test_code_version))
         if old_root is not None:
             environ['DESI_PRODUCT_ROOT'] = old_root
         if old_nersc_host is None:


### PR DESCRIPTION
This PR fixes the desiutil installation test at NERSC.  It was previously failing because it was picking `/global/common/edison/contrib/desi/code/desiutil/master` as the installation location, and then erroring because that already existed.

The test already included some logic to unset `$DESI_PRODUCT_ROOT` to try to avoid this, but that was unsuccessful because if that isn't set then the installation logic defaults to using `/global/common/edison/contrib/desi/code` anyway.

The workaround here is to test installing a fake branch "test-blat-foo".  An alternate workaround would have been to set `$DESI_PRODUCT_ROOT` to some other location instead of unsetting it.

Note: I purposefully didn't update changes.rst since this seems too small to bother cluttering the human-friendly log of important changes to know about; i.e. let's keep the changes.rst focused on features and changes in functionality.  @weaverba137 can override me as owner of this repo though.

For the record, this is what I get on edison when using desiutil master `python setup.py test`:
```
python setup.py test
...
======================================================================
ERROR: test_set_install_dir (desiutil.test.test_install.TestInstall)
Test the determination of the install directory.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/global/u2/s/sjbailey/temp/desiutil/py/desiutil/test/test_install.py", line 334, in test_set_install_dir
    install_dir = self.desiInstall.set_install_dir()
  File "/global/u2/s/sjbailey/temp/desiutil/py/desiutil/install.py", line 644, in set_install_dir
    raise DesiInstallException(message)
desiutil.install.DesiInstallException: Install directory, /global/common/edison/contrib/desi/code/desiutil/master, already exists!

----------------------------------------------------------------------
Ran 58 tests in 4.201s

FAILED (errors=1, skipped=1)
```