### PR TITLE
fix desiInstall on cori

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,7 @@ Change Log
 * Get .travis.yml file and other components ready for Python 3.6.
 * Increase test coverage in a few areas.
 * Make basemap_ an optional dependency (PR `#61`_).
+* fix desiInstall on cori
 
 .. _basemap: http://matplotlib.org/basemap/
 .. _`#61`: https://github.com/desihub/desiutil/pull/61

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -72,7 +72,12 @@ def init_modules(moduleshome=None, method=False, command=False):
         #
         # This is probably one of the primary NERSC systems, edison or cori.
         #
-        modulecmd = ['/opt/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ), 'python']
+        tmpcmd = '/opt/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ) 
+        # if that doesn't exist, try in /opt/cray/pe/modules (cori)
+        if not os.path.exists(tmpcmd):
+            tmpcmd = '/opt/cray/pe/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ) 
+
+        modulecmd = [tmpcmd, 'python']
         os.environ['MODULE_VERSION_STACK'] = os.environ['MODULE_VERSION']
     elif os.path.exists(os.path.join(moduleshome, 'modulecmd.tcl')):
         #

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -72,10 +72,10 @@ def init_modules(moduleshome=None, method=False, command=False):
         #
         # This is probably one of the primary NERSC systems, edison or cori.
         #
-        tmpcmd = '/opt/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ) 
+        tmpcmd = '/opt/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ)
         # if that doesn't exist, try in /opt/cray/pe/modules (cori)
         if not os.path.exists(tmpcmd):
-            tmpcmd = '/opt/cray/pe/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ) 
+            tmpcmd = '/opt/cray/pe/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ)
 
         modulecmd = [tmpcmd, 'python']
         os.environ['MODULE_VERSION_STACK'] = os.environ['MODULE_VERSION']

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -14,6 +14,13 @@ from __future__ import (absolute_import, division,
 # The line above will help with 2to3 support.
 
 
+try:
+    from shutil import which
+except ImportError:
+    # shutil.which() is Python 3.
+    from distutils.spawn import find_executable as which
+
+
 def init_modules(moduleshome=None, method=False, command=False):
     """Set up the Modules infrastructure.
 
@@ -68,31 +75,28 @@ def init_modules(moduleshome=None, method=False, command=False):
             os.environ['MODULEPATH'] = ':'.join(path)
     if 'LOADEDMODULES' not in os.environ:
         os.environ['LOADEDMODULES'] = ''
-    if 'MODULE_VERSION' in os.environ:
-        #
-        # This is probably one of the primary NERSC systems, edison or cori.
-        #
-        tmpcmd = '/opt/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ)
-        # if that doesn't exist, try in /opt/cray/pe/modules (cori)
-        if not os.path.exists(tmpcmd):
-            tmpcmd = '/opt/cray/pe/modules/{MODULE_VERSION}/bin/modulecmd'.format(**os.environ)
-
-        modulecmd = [tmpcmd, 'python']
-        os.environ['MODULE_VERSION_STACK'] = os.environ['MODULE_VERSION']
-    elif os.path.exists(os.path.join(moduleshome, 'modulecmd.tcl')):
+    if os.path.exists(os.path.join(moduleshome, 'modulecmd.tcl')):
         #
         # TCL version!
         #
         if 'TCLSH' in os.environ:
             tclsh = os.environ['TCLSH']
         else:
-            tclsh = '/usr/bin/tclsh'
+            tclsh = which('tclsh')
+        if tclsh is None:
+            raise ValueError("TCL Modules detected, but no tclsh excecutable found.")
         modulecmd = [tclsh, os.path.join(moduleshome, 'modulecmd.tcl'), 'python']
     else:
         #
-        # This is the path on NERSC data transfer nodes.
+        # This should work on all NERSC systems, assuming the user's environment
+        # is not totally screwed up.
         #
-        modulecmd = ['/usr/bin/modulecmd', 'python']
+        tmpcmd = which('modulecmd')
+        if tmpcmd is None:
+            raise ValueError("Modules environment detected, but no 'modulecmd' excecutable found.")
+        modulecmd = [tmpcmd, 'python']
+    if 'MODULE_VERSION' in os.environ:
+        os.environ['MODULE_VERSION_STACK'] = os.environ['MODULE_VERSION']
     if command:
         return modulecmd
     def desiutil_module(command, *arguments):


### PR DESCRIPTION
This PR fixes desiInstall for cori, but i'm not sure it is the best solution (see below)

Previously desiInstall looked for `modulecmd` in `/opt/modules/${MODULE_VERSION}/bin/modulecmd`.  That is true for some but not all versions of modules at NERSC; in particular it is not true for the current version of modules on cori (3.2.10.5).  This PR works around that by also checking `/opt/cray/pe/modules/${MODULE_VERSION}/bin/modulecmd` instead.

For consideration: I think it would be better for this whole section to use `distutils.spawn.find_executable('modulecmd')` rather than special casing the likely location on multiple machines.  So I'm offering the minimal fix in this PR, but perhaps we should use `find_executable` or similar instead.