### PR TITLE
Fix svn tests

### DIFF
--- a/py/desiutil/test/test_svn.py
+++ b/py/desiutil/test/test_svn.py
@@ -125,17 +125,13 @@ class TestSvn(unittest.TestCase):
     def test_version(self):
         """Test svn version parser.
         """
-        v = version('svn_test', url=self.svn_url)
-        self.assertEqual(v, '0.2.1.dev0',
-                         'Failed to extract version, got {0}.'.format(v))
+        if self.has_subversion:
+            v = version('svn_test', url=self.svn_url)
+            self.assertEqual(v, '0.2.1.dev0',
+                             'Failed to extract version, got {0}.'.format(v))
         v = version('foo_bar')
         self.assertEqual(v, '0.0.1.dev0', ('Failed to return default ' +
                          'version, got {0}.').format(v))
-        # if self.has_subversion:
-        #     v = version('svn_test',url=self.svn_url))
-        #     self.assertEqual(v,'0.2.1.dev2')
-        #     v = version('svn_test',url=self.svn_url)
-        #     self.assertEqual(v,'0.2.1.dev2')
 
 
 def test_suite():

--- a/py/desiutil/test/test_svn.py
+++ b/py/desiutil/test/test_svn.py
@@ -10,6 +10,7 @@ from os import environ
 from os.path import abspath, dirname, isdir, join
 from subprocess import Popen, PIPE
 from shutil import rmtree
+# from pkg_resources import resource_filename
 from ..svn import last_revision, last_tag, version
 
 
@@ -29,6 +30,17 @@ class TestSvn(unittest.TestCase):
         cls.has_subversion = p.returncode == 0
         if cls.has_subversion:
             try:
+                #
+                # It is possible for the *system* versions of svn and
+                # svnadmin to be out of sync at NERSC.
+                #
+                p = Popen(['svn', '--version'], stdout=PIPE, stderr=PIPE)
+                out, err = p.communicate()
+                svn_version = out.split('\n')[0].split(',')[1].strip()
+                p = Popen(['svnadmin', '--version'], stdout=PIPE, stderr=PIPE)
+                out, err = p.communicate()
+                svnadmin_version = out.split('\n')[0].split(',')[1].strip()
+                assert svn_version == svnadmin_version
                 cls.svn_url = 'file://' + cls.svn_path
                 p = Popen(['svnadmin', 'create', cls.svn_path],
                           stdout=PIPE, stderr=PIPE)
@@ -57,15 +69,18 @@ class TestSvn(unittest.TestCase):
                 assert p.returncode == 0
             except AssertionError:
                 cls.has_subversion = False
-                rmtree(cls.svn_path)
-                rmtree(cls.svn_checkout_path)
-        # Create an environment variable pointing to a dummy product.
-        if isdir(cls.svn_checkout_path):
-            if 'SVN_TEST_DIR' in environ:
-                cls.old_svn_test_dir = environ['SVN_TEST_DIR']
-            else:
-                cls.old_svn_test_dir = None
-            environ['SVN_TEST_DIR'] = cls.svn_checkout_path
+                try:
+                    rmtree(cls.svn_path)
+                    rmtree(cls.svn_checkout_path)
+                except FileNotFoundError:
+                    pass
+            # Create an environment variable pointing to a dummy product.
+            if isdir(cls.svn_checkout_path):
+                if 'SVN_TEST_DIR' in environ:
+                    cls.old_svn_test_dir = environ['SVN_TEST_DIR']
+                else:
+                    cls.old_svn_test_dir = None
+                environ['SVN_TEST_DIR'] = cls.svn_checkout_path
 
     @classmethod
     def tearDownClass(cls):
@@ -73,10 +88,10 @@ class TestSvn(unittest.TestCase):
         if cls.has_subversion:
             rmtree(cls.svn_path)
             rmtree(cls.svn_checkout_path)
-        if cls.old_svn_test_dir is None:
-            del environ['SVN_TEST_DIR']
-        else:
-            environ['SVN_TEST_DIR'] = cls.old_svn_test_dir
+            if cls.old_svn_test_dir is None:
+                del environ['SVN_TEST_DIR']
+            else:
+                environ['SVN_TEST_DIR'] = cls.old_svn_test_dir
 
     def test_last_revision(self):
         """Test svn revision number determination.

--- a/py/desiutil/test/test_svn.py
+++ b/py/desiutil/test/test_svn.py
@@ -36,10 +36,10 @@ class TestSvn(unittest.TestCase):
                 #
                 p = Popen(['svn', '--version'], stdout=PIPE, stderr=PIPE)
                 out, err = p.communicate()
-                svn_version = out.split('\n')[0].split(',')[1].strip()
+                svn_version = out.decode('ascii').split('\n')[0].split(',')[1].strip()
                 p = Popen(['svnadmin', '--version'], stdout=PIPE, stderr=PIPE)
                 out, err = p.communicate()
-                svnadmin_version = out.split('\n')[0].split(',')[1].strip()
+                svnadmin_version = out.decode('ascii').split('\n')[0].split(',')[1].strip()
                 assert svn_version == svnadmin_version
                 cls.svn_url = 'file://' + cls.svn_path
                 p = Popen(['svnadmin', 'create', cls.svn_path],


### PR DESCRIPTION
This PR deals with a few bugs in `test_svn.py` (not the `desiutil.svn` module itself).  At NERSC, we discovered that the system versions of `svn` and `svnadmin` can be out of sync (see #75).  This PR checks that these utilities have the same version.  It also catches a few cases where tests would run anyway even if the subversion infrastructure wasn't working.