### PR TITLE
Fix NERSC environment test failures

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ Change Log
 1.9.7 (unreleased)
 ------------------
 
-* No changes yet.
+* Fixed some test failures that occurred in the NERSC environment and/or
+  in an installed package, as opposed to a git checkout (PR `#80`_).
+
+.. _`#80`: https://github.com/desihub/desiutil/pull/80
+
 
 1.9.6 (2017-07-12)
 ------------------

--- a/py/desiutil/test/__init__.py
+++ b/py/desiutil/test/__init__.py
@@ -1,5 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-
-from .desiutil_test_suite import runtests
+#
+# Don't import this function.  It causes a scary-seeming warning of the form:
+# .../lib/python3.5/runpy.py:125: RuntimeWarning:
+#     'desiutil.test.desiutil_test_suite' found in sys.modules after
+#     import of package 'desiutil.test', but prior to execution of
+#     'desiutil.test.desiutil_test_suite'; this may result in unpredictable behaviour
+#        warn(RuntimeWarning(msg))
+#
+# from .desiutil_test_suite import runtests

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -85,7 +85,7 @@ class TestInstall(unittest.TestCase):
                 env_settings[key]['old'] = environ[key]
             environ[key] = env_settings[key]['new']
         default_namespace = Namespace(
-            anaconda='current',
+            anaconda=self.desiInstall.anaconda_version(),
             bootstrap=False,
             config_file='',
             cross_install=False,

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -309,7 +309,10 @@ class TestInstall(unittest.TestCase):
         options = self.desiInstall.get_options(['desiutil', 'master'])
         self.desiInstall.nersc = 'edison'
         nersc_dir = self.desiInstall.default_nersc_dir()
-        self.assertEqual(nersc_dir, '/global/common/edison/contrib/desi/desiconda/current')
+        edison_nersc_dir = '/global/common/edison/contrib/desi/desiconda/current'
+        if 'DESICONDA' in environ:
+            edison_nersc_dir = edison_nersc_dir.replace('current', self.desiInstall.anaconda_version())
+        self.assertEqual(nersc_dir, edison_nersc_dir)
         options = self.desiInstall.get_options(['--anaconda',
                                                 'frobulate',
                                                 'desiutil', 'master'])

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -396,6 +396,7 @@ class TestInstall(unittest.TestCase):
                          "with MODULESHOME={0}!").format(
                          '/fake/modules/directory'))
         options = self.desiInstall.get_options(['desiutil', 'master'])
+        self.assertEqual(options.moduleshome, environ['MODULESHOME'])
         status = self.desiInstall.start_modules()
         self.assertTrue(callable(self.desiInstall.module))
 

--- a/py/desiutil/test/test_setup.py
+++ b/py/desiutil/test/test_setup.py
@@ -32,16 +32,17 @@ class TestSetup(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(os.path.join(cls.setup_dir, cls.fake_name),
-                      ignore_errors=True)
-        shutil.rmtree(os.path.join(cls.data_dir, cls.fake_name),
-                      ignore_errors=True)
+        pass
 
     def setUp(self):
         os.chdir(self.original_dir)
 
     def tearDown(self):
         os.chdir(self.original_dir)
+        shutil.rmtree(os.path.join(self.setup_dir, self.fake_name),
+                      ignore_errors=True)
+        shutil.rmtree(os.path.join(self.data_dir, self.fake_name),
+                      ignore_errors=True)
 
     def run_setup(self, *args, **kwargs):
         """In Python 3, on MacOS X, the import cache has to be invalidated

--- a/py/desiutil/test/test_setup.py
+++ b/py/desiutil/test/test_setup.py
@@ -130,7 +130,7 @@ setup(name="{0.fake_name}",
             #
             # Running in an installed package, not a git or svn checkout.
             #
-            v = get_version(self.fake_name, tag='1.2.3')
+            update_version(self.fake_name, tag='1.2.3')
         self.assertTrue(os.path.exists(os.path.join(p, '_version.py')))
         os.remove(os.path.join(p, '_version.py'))
         os.rmdir(p)
@@ -149,7 +149,6 @@ setup(name="{0.fake_name}",
             # Running in an installed package, not a git or svn checkout.
             #
             update_version(self.fake_name, tag='0.1.2')
-        update_version(self.fake_name)
         self.assertTrue(os.path.exists(os.path.join(p, '_version.py')))
         update_version(self.fake_name, tag='1.2.3')
         with open(os.path.join(p, '_version.py')) as f:


### PR DESCRIPTION
This PR

* Fixes #78 
* Fixes #79 
* Does not change the actual desiutil API in anyway.  The only changes are to the test suite.

This PR can be merged at any time, but there is no need to immediately tag desiutil, since there are no API changes.