### PR TITLE
add unit test demonstrating failure of Brick.brick_radec() on scalar inputs

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+* Fixed bug in desiutil.brick.Brick.brick_radec() handling scalar inputs.
+
+.. _`#81`: https://github.com/desihub/desiutil/pull/81
+
 1.9.7 (unreleased)
 ------------------
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,18 +2,16 @@
 Change Log
 ==========
 
-* Fixed bug in desiutil.brick.Brick.brick_radec() handling scalar inputs.
-
-.. _`#81`: https://github.com/desihub/desiutil/pull/81
-
 1.9.7 (unreleased)
 ------------------
 
 * Fixed some test failures that occurred in the NERSC environment and/or
   in an installed package, as opposed to a git checkout (PR `#80`_).
+* Fixed bug in :meth:`desiutil.brick.Bricks.brick_radec` handling scalar inputs
+  (PR `#81`_).
 
 .. _`#80`: https://github.com/desihub/desiutil/pull/80
-
+.. _`#81`: https://github.com/desihub/desiutil/pull/81
 
 1.9.6 (2017-07-12)
 ------------------
@@ -30,7 +28,6 @@ Change Log
 * Improved correctness and functionality of :mod:`desiutil.brick` (PR `#74`_).
 
 .. _`#74`: https://github.com/desihub/desiutil/pull/74
-
 
 1.9.4 (2017-06-01)
 ------------------

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -281,7 +281,7 @@ class Bricks(object):
         ara, adec = self._array_radec(ra, dec)
         irow, icol = self._row_col(ara, adec)
         if np.isscalar(ra):
-            xra = self._center_ra[irow][icol]
+            xra = self._center_ra[irow[0]][icol]
             xdec = self._center_dec[irow]
         else:
             xra = np.array([self._center_ra[i][j] for i,j in zip(irow, icol)])

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -251,6 +251,26 @@ class TestBrick(unittest.TestCase):
         self.assertEqual(B._bricks.bricksize, 0.25)
         B._bricks = None
 
+    def test_brick_radec_scalar(self):
+        """Test scalar to brick RA,Dec conversion.
+        """
+        b = B.Bricks(bricksize=1.)
+        ra,dec = b.brick_radec(0., 0.)
+        self.assertEqual(ra, 0.5)
+        self.assertEqual(dec, 0.)
+
+    def test_brick_radec_array(self):
+        """Test scalar to brick RA,Dec conversion.
+        """
+        b = B.Bricks(bricksize=1.)
+        ra,dec = b.brick_radec(np.array([0., 1.]), np.array([0.,0.]))
+        self.assertEqual(len(ra), 2)
+        self.assertEqual(len(dec), 2)
+        self.assertEqual(ra[0], 0.5)
+        self.assertEqual(dec[0], 0.)
+        self.assertEqual(ra[1], 1.5)
+        self.assertEqual(dec[1], 0.)
+
     def test_to_table(self):
         """Test conversion to table.
         """

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -260,7 +260,7 @@ class TestBrick(unittest.TestCase):
         self.assertEqual(dec, 0.)
 
     def test_brick_radec_array(self):
-        """Test scalar to brick RA,Dec conversion.
+        """Test array to brick RA,Dec conversion.
         """
         b = B.Bricks(bricksize=1.)
         ra,dec = b.brick_radec(np.array([0., 1.]), np.array([0.,0.]))


### PR DESCRIPTION
Fails with:
======================================================================
ERROR: test_brick_radec_scalar (desiutil.test.test_brick.TestBrick)
Test scalar to brick RA,Dec conversion.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dstn/desiutil/py/desiutil/test/test_brick.py", line 258, in test_brick_radec_scalar
    ra,dec = b.brick_radec(0., 0.)
  File "/Users/dstn/desiutil/py/desiutil/brick.py", line 284, in brick_radec
    xra = self._center_ra[irow][icol]
TypeError: only integer scalar arrays can be converted to a scalar index

----------------------------------------------------------------------

irow and icol are numpy arrays of integers with one element each.


