### PR TITLE
Fix bugs that caused bricks to be larger than bricksize.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,9 +9,13 @@ Change Log
   in an installed package, as opposed to a git checkout (PR `#80`_).
 * Fixed bug in :meth:`desiutil.brick.Bricks.brick_radec` handling scalar inputs
   (PR `#81`_).
+* Fixed bugs that could cause bricks to be slightly too big, and that
+  incorrectly special-cased the north pole with brick sizes that don't
+  evenly divide 180 degrees (PR `#82`_).
 
 .. _`#80`: https://github.com/desihub/desiutil/pull/80
 .. _`#81`: https://github.com/desihub/desiutil/pull/81
+.. _`#82`: https://github.com/desihub/desiutil/pull/82
 
 1.9.6 (2017-07-12)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,11 +11,11 @@ Change Log
   (PR `#81`_).
 * Fixed bugs that could cause bricks to be slightly too big, and that
   incorrectly special-cased the north pole with brick sizes that don't
-  evenly divide 180 degrees (PR `#82`_).
+  evenly divide 180 degrees (PR `#84`_).
 
 .. _`#80`: https://github.com/desihub/desiutil/pull/80
 .. _`#81`: https://github.com/desihub/desiutil/pull/81
-.. _`#82`: https://github.com/desihub/desiutil/pull/82
+.. _`#84`: https://github.com/desihub/desiutil/pull/84
 
 1.9.6 (2017-07-12)
 ------------------

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -52,7 +52,7 @@ class Bricks(object):
         ncol_per_row = np.zeros(nrow, dtype=int)
         for i in range(nrow):
             declo = np.abs(center_dec[i])-bricksize/2
-            n = (360/bricksize * np.cos(declo*np.pi/180))
+            n = (360/bricksize * np.cos(np.deg2rad(declo)))
             ncol_per_row[i] = int(np.ceil(n/2)*2)
 
         #- special cases at the poles

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -128,6 +128,7 @@ class Bricks(object):
         """Determine the brick row and column, given `ra`, `dec`.
         """
         row = ((dec+90.0+self._bricksize/2)/self._bricksize).astype(int)
+        row = np.clip(row, 0, len(self._ncol_per_row)-1)
         return (row, (ra/360.0 * self._ncol_per_row[row]).astype(int))
 
     def brickname(self, ra, dec):

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -52,7 +52,8 @@ class Bricks(object):
         ncol_per_row = np.zeros(nrow, dtype=int)
         for i in range(nrow):
             # The widest part of the brick is at the Dec closest to
-            # the equator
+            # the equator.  max(0, ...) handles a row that spans the
+            # Dec=0 equator.
             declo = max(0, np.abs(center_dec[i]) - bricksize/2)
             n = (360/bricksize * np.cos(np.deg2rad(declo)))
             ncol_per_row[i] = int(np.ceil(n/2)*2)

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -60,7 +60,8 @@ class Bricks(object):
 
         #- special cases at the poles
         ncol_per_row[0] = 1
-        ncol_per_row[-1] = 1
+        if center_dec[-1] == 90.:
+            ncol_per_row[-1] = 1
 
         #- ra
         center_ra = list()
@@ -73,8 +74,11 @@ class Bricks(object):
             # center_ra.append(dra/2 + np.arange(ncol_per_row[i])*dra)
 
         #- More special cases at the poles
-        edges_ra[0] = edges_ra[-1] = np.array([0, 360])
-        center_ra[0] = center_ra[-1] = np.array([180,])
+        edges_ra[0] = np.array([0, 360])
+        center_ra[0] = np.array([180,])
+        if center_dec[-1] == 90.:
+            edges_ra[-1] = np.array([0, 360])
+            center_ra[-1] = np.array([180,])
 
         #- Brick names [row, col]
         brickname = list()

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -51,7 +51,9 @@ class Bricks(object):
         #- How many columns per row: even number, no bigger than bricksize
         ncol_per_row = np.zeros(nrow, dtype=int)
         for i in range(nrow):
-            declo = np.abs(center_dec[i])-bricksize/2
+            # The widest part of the brick is at the Dec closest to
+            # the equator
+            declo = max(0, np.abs(center_dec[i]) - bricksize/2)
             n = (360/bricksize * np.cos(np.deg2rad(declo)))
             ncol_per_row[i] = int(np.ceil(n/2)*2)
 

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -39,6 +39,8 @@ class Bricks(object):
     def __init__(self, bricksize=0.25):
         #- Brick row centers and edges
         center_dec = np.arange(-90.0, +90.0+bricksize/2, bricksize)
+        # clip the north pole to +90
+        center_dec[-1] = min(90., center_dec[-1])
         edges_dec = np.arange(-90.0-bricksize/2, +90.0+bricksize, bricksize)
         # poles
         edges_dec[0] = -90.

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -96,9 +96,9 @@ class TestBrick(unittest.TestCase):
         r,d = b.brick_radec(0., 90.)
         self.assertTrue(d <= 90.)
 
-        # If one row spans Dec=0, the number of bricks in that row may
-        # be set incorrectly.
-        # This happens for lots of different values, as low as 0.1 deg
+        # If one row spans Dec=0, the number of bricks in that row
+        # used to be set incorrectly.  This happened for lots of
+        # different values, as low as 0.1 deg
         bricksize = 9.97
         b = B.Bricks(bricksize=bricksize)
         a = b.brickarea(0., 0.)
@@ -114,6 +114,13 @@ class TestBrick(unittest.TestCase):
         # Measure the brick width at Dec=0 (the widest point)
         r0,r1 = v[0,0],v[1,0]
         self.assertTrue(np.abs(r1 - r0) <= bricksize)
+
+        # Big bricks (that don't evenly divide 180) can cause issues too
+        bricksize = 8.0
+        b = B.Bricks(bricksize=bricksize)
+        a = b.brickarea(0., 90.)
+        print('Area', a)
+        self.assertTrue(a <= bricksize**2)
 
     def test_brickarea_scalar(self):
         """Test scalar to brick area conversion.

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -85,6 +85,36 @@ class TestBrick(unittest.TestCase):
         self.assertEqual(np.max(b1[:,0])-np.min(b1[:,0]), 360.)
         self.assertTrue(np.all(b1[:,1] >= -90.))
 
+    def test_uneven_bricksize(self):
+        # Brick sizes that evenly divide 180 degrees work fine
+        b = B.Bricks(bricksize=0.25)
+        r,d = b.brick_radec(0., 90.)
+        self.assertTrue(d <= 90.)
+
+        # Strange brick size
+        b = B.Bricks(bricksize=0.23)
+        r,d = b.brick_radec(0., 90.)
+        self.assertTrue(d <= 90.)
+
+        # If one row spans Dec=0, the number of bricks in that row may
+        # be set incorrectly.
+        # This happens for lots of different values, as low as 0.1 deg
+        bricksize = 9.97
+        b = B.Bricks(bricksize=bricksize)
+        a = b.brickarea(0., 0.)
+        self.assertTrue(np.sqrt(a) <= bricksize)
+        v = b.brickvertices(0., 0.)
+        # First two vertices are the bottom edge
+        d0,d1 = v[0,1],v[1,1]
+        self.assertTrue(d0 == d1)
+        d2 = v[2,1]
+        # Third vertex is positive Dec.
+        self.assertTrue((d0 < 0) and (d2 > 0))
+        # Thus the vertex spans Dec=0
+        # Measure the brick width at Dec=0 (the widest point)
+        r0,r1 = v[0,0],v[1,0]
+        self.assertTrue(np.abs(r1 - r0) <= bricksize)
+
     def test_brickarea_scalar(self):
         """Test scalar to brick area conversion.
         """

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -86,6 +86,7 @@ class TestBrick(unittest.TestCase):
         self.assertTrue(np.all(b1[:,1] >= -90.))
 
     def test_uneven_bricksize(self):
+        """Test with bricksizes that do not evenly divide 180 degrees."""
         # Brick size that evenly divides 180 degrees
         b = B.Bricks(bricksize=0.25)
         r,d = b.brick_radec(0., 90.)

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -86,7 +86,7 @@ class TestBrick(unittest.TestCase):
         self.assertTrue(np.all(b1[:,1] >= -90.))
 
     def test_uneven_bricksize(self):
-        # Brick sizes that evenly divide 180 degrees work fine
+        # Brick size that evenly divides 180 degrees
         b = B.Bricks(bricksize=0.25)
         r,d = b.brick_radec(0., 90.)
         self.assertTrue(d <= 90.)
@@ -115,11 +115,11 @@ class TestBrick(unittest.TestCase):
         r0,r1 = v[0,0],v[1,0]
         self.assertTrue(np.abs(r1 - r0) <= bricksize)
 
-        # Big bricks (that don't evenly divide 180) can cause issues too
+        # Big bricks (that don't evenly divide 180) could cause issues
+        # too
         bricksize = 8.0
         b = B.Bricks(bricksize=bricksize)
         a = b.brickarea(0., 90.)
-        print('Area', a)
         self.assertTrue(a <= bricksize**2)
 
     def test_brickarea_scalar(self):


### PR DESCRIPTION
Fixes some implicit assumptions that bricksize evenly divides 180 degrees:
* don't assume the last brick is at the north pole (Dec=90)
* avoid Dec edges exceeding 90 degrees
* avoid Dec array indexing error
* fix handling of the equator in computing required number of bricks in a row
