### PR TITLE
Independent log levels

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,9 +7,13 @@ Change Log
 
 * Enhance :mod:`desiutil.log` with a context manager (PR `#92`_), and
   change the way the log level is set.
+* Avoid logging interference with :func:`desiutil.log.get_logger` is called
+  with different log levels (PR `#93`_).
 * Use :mod:`unittest.mock` to increase test coverage.
 
 .. _`#92`: https://github.com/desihub/desiutil/pull/92
+.. _`#93`: https://github.com/desihub/desiutil/pull/93
+
 
 1.9.8 (2017-11-09)
 ------------------

--- a/py/desiutil/log.py
+++ b/py/desiutil/log.py
@@ -159,8 +159,9 @@ def _configure_root_logger(timestamp=False, delimiter=':'):
         fmtfields = ['%(levelname)s', '%(filename)s', '%(lineno)s', '%(funcName)s']
         if timestamp:
             fmtfields.append('%(asctime)s')
-        fmt = delimiter.join(fmtfields)
-        formatter = logging.Formatter(fmt + ': %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
+        fmtfields.append(' %(message)s')
+        formatter = logging.Formatter(delimiter.join(fmtfields),
+                                      datefmt='%Y-%m-%dT%H:%M:%S')
         ch.setFormatter(formatter)
         _desiutil_log_root[root_name] = logging.getLogger(root_name)
         _desiutil_log_root[root_name].addHandler(ch)

--- a/py/desiutil/test/test_census.py
+++ b/py/desiutil/test/test_census.py
@@ -64,21 +64,23 @@ class TestCensus(unittest.TestCase):
         """Test error-handling function for os.walk().
         """
         from ..census import walk_error
-        with patch('desiutil.log.desi_logger') as mock:
+        with patch('desiutil.log.get_logger') as mock_get_logger:
+            mock = Mock()
+            mock_get_logger.return_value = mock
             try:
                 raise OSError(2, 'File not found', 'foo.txt')
             except OSError as e:
                 walk_error(e)
-            calls = [call.setLevel(20),
-                     call.error("[Errno 2] File not found: 'foo.txt'")]
+            calls = [call.error("[Errno 2] File not found: 'foo.txt'")]
             self.assertListEqual(mock.mock_calls, calls)
-        with patch('desiutil.log.desi_logger') as mock:
+        with patch('desiutil.log.get_logger') as mock_get_logger:
+            mock = Mock()
+            mock_get_logger.return_value = mock
             try:
                 raise OSError(2, 'File not found', 'foo.txt', None, 'bar.txt')
             except OSError as e:
                 walk_error(e)
-            calls = [call.setLevel(20),
-                     call.error("[Errno 2] File not found: 'foo.txt' -> " +
+            calls = [call.error("[Errno 2] File not found: 'foo.txt' -> " +
                                 "'bar.txt'")]
             self.assertListEqual(mock.mock_calls, calls)
 
@@ -110,12 +112,13 @@ class TestCensus(unittest.TestCase):
         #
         # Simulate a simple file.
         #
-        calls = [call.setLevel(20),
-                 call.debug("os.stat('{0}')".format(fd)),
+        calls = [call.debug("os.stat('{0}')".format(fd)),
                  call.warning("{0} does not have correct group id!".format(fd))]
-        with patch('desiutil.log.desi_logger') as mock_log:
+        mock_log = Mock()
+        with patch('desiutil.log.get_logger') as mock_get_logger:
             with patch.dict('sys.modules', {'os': mock_os,
                                             'os.path': mock_os.path}):
+                mock_get_logger.return_value = mock_log
                 mock_os.environ = dict()
                 mock_os.stat.return_value = s
                 mock_os.path.islink.return_value = False
@@ -128,15 +131,16 @@ class TestCensus(unittest.TestCase):
         #
         # Simulate an internal link.
         #
-        calls = [call.setLevel(20),
-                 call.debug("os.stat('{0}')".format(fd)),
+        calls = [call.debug("os.stat('{0}')".format(fd)),
                  call.warning("{0} does not have correct group id!".format(fd)),
                  call.debug("os.lstat('{0}')".format(fd)),
                  call.warning("{0} does not have correct group id!".format(fd)),
                  call.debug("Found internal link {0} -> {0}.link.".format(fd))]
-        with patch('desiutil.log.desi_logger') as mock_log:
+        mock_log = Mock()
+        with patch('desiutil.log.get_logger') as mock_get_logger:
             with patch.dict('sys.modules', {'os': mock_os,
                                             'os.path': mock_os.path}):
+                mock_get_logger.return_value = mock_log
                 mock_os.environ = dict()
                 mock_os.stat.return_value = s
                 mock_os.lstat.return_value = s
@@ -154,15 +158,16 @@ class TestCensus(unittest.TestCase):
         #
         # Simulate an external link.
         #
-        calls = [call.setLevel(20),
-                 call.debug("os.stat('{0}')".format(fd)),
+        calls = [call.debug("os.stat('{0}')".format(fd)),
                  call.warning("{0} does not have correct group id!".format(fd)),
                  call.debug("os.lstat('{0}')".format(fd)),
                  call.warning("{0} does not have correct group id!".format(fd)),
                  call.debug("Found external link {0} -> {1}.".format(fd, extlink))]
-        with patch('desiutil.log.desi_logger') as mock_log:
+        mock_log = Mock()
+        with patch('desiutil.log.get_logger') as mock_get_logger:
             with patch.dict('sys.modules', {'os': mock_os,
                                             'os.path': mock_os.path}):
+                mock_get_logger.return_value = mock_log
                 mock_os.environ = dict()
                 mock_os.stat.return_value = s
                 mock_os.lstat.return_value = s

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -127,6 +127,23 @@ class TestDepend(unittest.TestCase):
 
         for name, version in iterdep(hdr):
             self.assertEqual(version, getdep(hdr, name))
+        #
+        # Test dependency index starting from one.
+        #
+        hdr = dict()
+        for j in range(1, 20):
+            hdr["DEPNAM{0:02d}".format(i)] = "test{0:03d}".format(i)
+            hdr["DEPVER{0:02d}".format(i)] = "v{0:d}.0.1".format(i)
+        y = Dependencies(hdr)
+        for name in y:
+            self.assertEqual(y[name], getdep(hdr, name))
+
+        for name, version in y.items():
+            self.assertEqual(version, getdep(hdr, name))
+
+        for name, version in iterdep(hdr):
+            self.assertEqual(version, getdep(hdr, name))
+
 
     def test_class(self):
         """Test the Dependencies object.
@@ -166,9 +183,11 @@ class TestDepend(unittest.TestCase):
         self.assertFalse(hasdep(hdr, 'quatlarm'))
 
         # no .__version__
-        add_dependencies(hdr, ['os.path', 'sys'])
+        add_dependencies(hdr, ['os.path', 'unittest', 'sys'])
         self.assertTrue(hasdep(hdr, 'os.path'))
         self.assertTrue(getdep(hdr, 'os.path').startswith('unknown'))
+        self.assertTrue(hasdep(hdr, 'unittest'))
+        self.assertTrue(getdep(hdr, 'unittest').startswith('unknown'))
         self.assertTrue(hasdep(hdr, 'sys'))
         self.assertTrue(getdep(hdr, 'sys').startswith('unknown'))
 

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -11,6 +11,7 @@ from os.path import dirname, isdir, join
 from shutil import rmtree
 from argparse import Namespace
 from tempfile import mkdtemp
+from logging import getLogger
 from pkg_resources import resource_filename
 from ..log import DEBUG
 from ..install import DesiInstall, DesiInstallException, dependencies
@@ -41,13 +42,14 @@ class TestInstall(unittest.TestCase):
         # Create a "fresh" DesiInstall object for every test.
         self.desiInstall = DesiInstall()
         # Replace the log handler with something that writes to memory.
-        while len(self.desiInstall.log.handlers) > 0:
-            h = self.desiInstall.log.handlers[0]
+        root_logger = getLogger(self.desiInstall.log.name.rsplit('.', 1)[0])
+        while len(root_logger.handlers) > 0:
+            h = root_logger.handlers[0]
             fmt = h.formatter
-            self.desiInstall.log.removeHandler(h)
+            root_logger.removeHandler(h)
         mh = TestHandler()
         mh.setFormatter(fmt)
-        self.desiInstall.log.addHandler(mh)
+        root_logger.addHandler(mh)
         self.desiInstall.log.setLevel(DEBUG)
         # Create a temporary directory.
         self.data_dir = mkdtemp()
@@ -58,7 +60,7 @@ class TestInstall(unittest.TestCase):
     def assertLog(self, order=-1, message=''):
         """Examine the log messages.
         """
-        handler = self.desiInstall.log.handlers[0]
+        handler = getLogger(self.desiInstall.log.name.rsplit('.', 1)[0]).handlers[0]
         record = handler.buffer[order]
         self.assertEqual(record.getMessage(), message)
 

--- a/py/desiutil/test/test_log.py
+++ b/py/desiutil/test/test_log.py
@@ -35,7 +35,7 @@ class TestHandler(MemoryHandler):
 
 
 class TestLog(unittest.TestCase):
-    """Test desispec.log
+    """Test desiutil.log
     """
 
     @classmethod
@@ -55,7 +55,7 @@ class TestLog(unittest.TestCase):
         (:|\s--\s)                                        # delimiter
         (run_logs|test_log_context)                       # function
         ((:|\s--\s)\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}|)  # optional timetamp
-        :\s                                               # start of message
+        (:|\s--\s)\s                                      # start of message
         """, re.VERBOSE)
 
     @classmethod


### PR DESCRIPTION
This PR closes #66:

* Calls to `get_logger()` return different loggers, depending on log level and other configuration details, so that a logger of level `DEBUG` does not interfere with a logger of level `INFO`.
* Creates a default logger with default level `INFO` at import time.  This is available as `desiutil.log.log`, *e.g.*:
```python
from desiutil.log import log
log.info('Information.')
```