### PR TITLE
Add bspline to fitting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ before_install:
 install:
     - if [[ $MAIN_CMD == 'pycodestyle' ]]; then pip install pycodestyle; fi
     - if [[ $SETUP_CMD == build_sphinx* ]]; then pip install Sphinx; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then pip install scipy; fi  # Ugly kludge by JXP
     - if [[ $MAIN_CMD == 'coverage' ]]; then pip install coverage coveralls; fi
     - if [[ $SETUP_CMD == 'test' || $MAIN_CMD == 'coverage' ]]; then pip install -r requirements.txt; fi
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Change Log
 1.9.10 (unreleased)
 -------------------
 
-* Add bspline to funcfits
+* Add bspline to funcfits.  scipy is now a dependency
 
 1.9.9 (2017-12-20)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Change Log
 1.9.10 (unreleased)
 -------------------
 
-* No changes yet.
+* Add bspline to funcfits
 
 1.9.9 (2017-12-20)
 ------------------

--- a/py/desiutil/funcfits.py
+++ b/py/desiutil/funcfits.py
@@ -97,6 +97,9 @@ def func_fit(x, y, func, deg, xnorm=True, xmin=None, xmax=None, w=None, **kwargs
         Name of the fitting function:  polynomial, legendre, chebyshev, bspline.
     deg : :class:`int` or :class:`dict`
         Order of the fit.
+    xnorm : bool, optional
+      Normalize the x-values from -1 to 1?
+      This is *never* done for bspline
     xmin : :class:`float`, optional
         Minimum value in the array (or the left limit for a
         legendre/chebyshev polynomial).
@@ -113,12 +116,15 @@ def func_fit(x, y, func, deg, xnorm=True, xmin=None, xmax=None, w=None, **kwargs
     """
     # Normalize x values?
     if xnorm:
-        if xmin is None or xmax is None:
-            if x.size == 1:
-                xmin, xmax = -1.0, 1.0
-            else:
-                xmin, xmax = x.min(), x.max()
-        xv = 2.0 * (x-xmin)/(xmax-xmin) - 1.0
+        if func == 'bspline':  # Never normalized
+            xv = x
+        else:
+            if xmin is None or xmax is None:
+                if x.size == 1:
+                    xmin, xmax = -1.0, 1.0
+                else:
+                    xmin, xmax = x.min(), x.max()
+            xv = 2.0 * (x-xmin)/(xmax-xmin) - 1.0
     else:
         xv = x
     # Fit

--- a/py/desiutil/funcfits.py
+++ b/py/desiutil/funcfits.py
@@ -23,27 +23,27 @@ def bspline_fit(x,y,order=3,knots=None,everyn=20,xmin=None,xmax=None,w=None,bksp
     """ bspline fit to x,y
     Primarily a wrapper to the scipy function
 
-    Parameters:
-    ---------
-    x: ndarray
-    y: ndarray
-    order: int
+    Parameters
+    ----------
+    x : :class:`~numpy.ndarray`
+    y : :class:`~numpy.ndarray`
+    order : :class:`int`
       deg of the spline.  Default=3 (cubic)
-    knots: ndarray, optional
+    knots : :class:`~numpy.ndarray`, optional
       Internal knots only.  External ones are added by scipy
-    everyn: int, optional
+    everyn : :class:`int`, optional
       Knot everyn good pixels, if used
-    xmin: float, optional
+    xmin : :class:`float`, optional
       Minimum value in the array  [both must be set to normalize]
-    xmax: float, optional
+    xmax: :class:`float`, optional
       Maximum value in the array  [both must be set to normalize]
-    w: ndarray, optional
+    w : :class:`~numpy.ndarray`, optional
       weights to be used in the fitting (weights = 1/sigma)
-    bkspace: float, optional
+    bkspace: :class:`float`, optional
       Spacing of breakpoints in units of x
 
-    Returns:
-    ---------
+    Returns
+    -------
     tck : tuple
       describes the bspline
     """
@@ -97,7 +97,7 @@ def func_fit(x, y, func, deg, xnorm=True, xmin=None, xmax=None, w=None, **kwargs
         Name of the fitting function:  polynomial, legendre, chebyshev, bspline.
     deg : :class:`int` or :class:`dict`
         Order of the fit.
-    xnorm : bool, optional
+    xnorm : :class:`bool`, optional
       Normalize the x-values from -1 to 1?
       This is *never* done for bspline
     xmin : :class:`float`, optional

--- a/py/desiutil/test/test_funcfits.py
+++ b/py/desiutil/test/test_funcfits.py
@@ -64,6 +64,18 @@ class TestFuncFits(unittest.TestCase):
         y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99940823486206942)
 
+    def test_bspline_fit(self):
+        """Test bspline fit.
+        """
+        # Generate data
+        x = np.linspace(0, np.pi, 50)
+        y = np.sin(x)
+        # Fit
+        dfit = func_fit(x, y, 'bspline', 3)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
+        np.testing.assert_allclose(y2[50], 0.99837522123593681)
+
     def test_fit_with_sigma(self):
         """Test fit with sigma.
         """

--- a/py/desiutil/test/test_funcfits.py
+++ b/py/desiutil/test/test_funcfits.py
@@ -39,6 +39,11 @@ class TestFuncFits(unittest.TestCase):
         x2 = np.linspace(0, np.pi, 100)
         y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.97854984428713754)
+        # Without xnorm
+        dfit = func_fit(x, y, 'polynomial', 3, xnorm=False)
+        x2 = np.linspace(0, np.pi, 100)
+        y2 = func_val(x2, dfit)
+        np.testing.assert_allclose(y2[50], 0.97854984428713698)
 
     def test_legendre_fit(self):
         """Test Legendre fit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pyyaml
 astropy
 healpy
 matplotlib
+scipy
 # git+https://github.com/matplotlib/basemap.git


### PR DESCRIPTION
Mainly a wrapper to scipy.interpolate routines.
Integrated within the func_fits(), iter_fit(),
and func_val() methods.

Includes new tests.

Passing on my machine but failing coverage
test on Travis for unclear reasons.