### PR TITLE
update to more recent sklearn.mixture.GaussianMixture keywords

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 1.9.11 (unreleased)
 -------------------
 
-* No changes yet.
+* Update sklearn module to support updates to sklearn.mixture.GaussianMixture
+  (PR `#111`_).
+
+.. _`#111`: https://github.com/desihub/desiutil/pull/111
 
 1.9.10 (2018-03-29)
 -------------------

--- a/py/desiutil/sklearn.py
+++ b/py/desiutil/sklearn.py
@@ -51,10 +51,16 @@ class GaussianMixtureModel(object):
         from astropy.io import fits
         hdus = fits.HDUList()
         hdr = fits.Header()
-        hdr['covtype'] = model.covtype
-        hdus.append(fits.ImageHDU(model.weights, name='weights', header=hdr))
-        hdus.append(fits.ImageHDU(model.means, name='means'))
-        hdus.append(fits.ImageHDU(model.covars, name='covars'))
+        try:
+            hdr['covtype'] = model.covariance_type
+            hdus.append(fits.ImageHDU(model.weights_, name='weights', header=hdr))
+            hdus.append(fits.ImageHDU(model.means_, name='means'))
+            hdus.append(fits.ImageHDU(model.covariances_, name='covars'))
+        except:
+            hdr['covtype'] = model.covtype
+            hdus.append(fits.ImageHDU(model.weights, name='weights', header=hdr))
+            hdus.append(fits.ImageHDU(model.means, name='means'))
+            hdus.append(fits.ImageHDU(model.covars, name='covars'))
         hdus.writeto(filename, overwrite=True)
 
     @staticmethod


### PR DESCRIPTION
The sklearn data model changed recently.  This simple PR supports both old and newer versions of `sklearn.mixture.GaussianMixture` which is used in a variety of places in `desihub`. 