### PR TITLE
adding the maps subdirectory to the dustdir variable

### DIFF
--- a/py/desiutil/dust.py
+++ b/py/desiutil/dust.py
@@ -167,11 +167,12 @@ class SFDMap(object):
 
     Parameters
     ----------
-    mapdir : :class:`str`, optional, defaults to :envvar:`DUST_DIR`.
+    mapdir : :class:`str`, optional, defaults to :envvar:`DUST_DIR`+``/maps``.
         Directory in which to find dust map FITS images, named
         ``SFD_dust_4096_ngp.fits`` and ``SFD_dust_4096_sgp.fits``.
-        If not specified, the value of the :envvar:`DUST_DIR` environment
-        variable is used, otherwise an empty string is used.
+        If not specified, the map directory is derived from the value of 
+        the :envvar:`DUST_DIR` environment variable, otherwise an empty 
+        string is used.
     north, south : :class:`str`, optional
         Names of north and south galactic pole FITS files. Defaults are
         ``SFD_dust_4096_ngp.fits`` and ``SFD_dust_4096_sgp.fits``
@@ -189,7 +190,8 @@ class SFDMap(object):
                  south="SFD_dust_4096_sgp.fits", scaling=1.):
 
         if mapdir is None:
-            mapdir = os.environ.get('DUST_DIR', '')
+            dustdir = os.environ.get('DUST_DIR', '')
+            mapdir = "{}/maps".format(dustdir)
         self.mapdir = mapdir
 
         # don't load maps initially


### PR DESCRIPTION
This PR updates the default directory used by `desiutil.dust` to add the `/maps` subdirectory to the `$DUST_DIR` environment variable.