### PR TITLE
remove write permission after installation

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,7 +10,9 @@ Change Log
 1.9.14 (unreleased)
 -------------------
 
-* No changes yet.
+* Restrict write access on software installed with :command:`desiInstall` (PR `#122`_).
+
+.. _`#122`: https://github.com/desihub/desiutil/pull/122
 
 1.9.13 (2018-09-06)
 -------------------

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -716,6 +716,11 @@ class DesiInstall(object):
                                module_directory)
                 mod = process_module(self.module_file, self.module_keywords,
                                      module_directory)
+                # Remove write permission to avoid accidental changes
+                outfile = os.path.join(module_directory,
+                                       self.module_keywords['name'],
+                                       self.module_keywords['version'])
+                os.chmod(outfile, 0o440)
             except OSError as ose:
                 self.log.critical(ose.strerror)
                 raise DesiInstallException(ose.strerror)
@@ -724,6 +729,7 @@ class DesiInstall(object):
                                module_directory)
                 dot_version = default_module(self.module_keywords,
                                              module_directory)
+
         return mod
 
     def prepare_environment(self):
@@ -945,6 +951,16 @@ class DesiInstall(object):
         out, err = proc.communicate()
         status = proc.returncode
         self.log.debug(out)
+
+        # Remove write permission to avoid accidental changes
+        command = ['chmod', '-R', 'a-w', self.install_dir]
+        self.log.debug(' '.join(command))
+        proc = Popen(command, universal_newlines=True,
+                     stdout=PIPE, stderr=PIPE)
+        out, err = proc.communicate()
+        chmod_status = proc.returncode
+        self.log.debug(out)
+
         return status
 
     def cleanup(self):

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -953,7 +953,11 @@ class DesiInstall(object):
         self.log.debug(out)
 
         # Remove write permission to avoid accidental changes
-        command = ['chmod', '-R', 'a-w', self.install_dir]
+        if self.is_trunk or self.is_branch:
+            chmod_mode = 'g-w,o-w'
+        else:
+            chmod_mode = 'a-w'
+        command = ['chmod', '-R', chmod_mode, self.install_dir]
         self.log.debug(' '.join(command))
         proc = Popen(command, universal_newlines=True,
                      stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
This PR updates `desiInstall` so that it removes write permission after an installation to protect against accidental changes later.  It purposefully removes write permission even from the installing user (e.g. `desi`).

Previously `desiInstall` would run `fix_permissions.sh` which leaves write-permission alone, leaving us in a state where any desi collaborator could accidentally delete a code installation.

I'd like to get this (or equivalent) into a new tag to include in the 18.9 release so that future installations will be safe from accidental overwrite.

changes.rst still needs to be updated, after this has a PR number and @weaverba137 approves of the approach implemented here.