### PR TITLE
Update permission settings in fix_permissions.sh

### DIFF
--- a/bin/fix_permissions.sh
+++ b/bin/fix_permissions.sh
@@ -92,9 +92,9 @@ fi
 findbase="${find} ${directory} -user ${USER}"
 [ "${verbose}" = "True" ] && echo "Fixing permissions on ${directory} ..."
 if [ "${test}" = "True" ]; then
-    run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /g+w -ls"
-    run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /o+rwx -ls"
-    run ${verbose} "${findbase} -group ${desiGID} -not -type l -perm /o+w -ls"
+    # run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /g+w -ls"
+    # run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /o+rwx -ls"
+    # run ${verbose} "${findbase} -group ${desiGID} -not -type l -perm /o+w -ls"
     run ${verbose} "${findbase} -not -group ${desiGID} -ls"
     run ${verbose} "${findbase} -type f -not -perm /g+r -ls"
     run ${verbose} "${findbase} -type d -not -perm -g+rxs -ls"
@@ -111,11 +111,11 @@ else
     #
     [ "${verbose}" = "True" ] && vflag='-c'
     # Remove group write access from things not in the group.
-    run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /g+w -exec chmod ${vflag} g-w {} ;"
+    # run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /g+w -exec chmod ${vflag} g-w {} ;"
     # Remove all world access from things not in the group.
-    run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /o+rwx -exec chmod ${vflag} o-rwx {} ;"
+    # run ${verbose} "${findbase} -not -group ${desiGID} -not -type l -perm /o+rwx -exec chmod ${vflag} o-rwx {} ;"
     # Remove world write access from things already in the group.
-    run ${verbose} "${findbase} -group ${desiGID} -not -type l -perm /o+w -exec chmod ${vflag} o-w {} ;"
+    # run ${verbose} "${findbase} -group ${desiGID} -not -type l -perm /o+w -exec chmod ${vflag} o-w {} ;"
     # Change group.
     run ${verbose} "${findbase} -not -group ${desiGID} -exec chgrp ${vflag} -h ${desiGID} {} ;"
     # Set group read access.


### PR DESCRIPTION
This PR modifies the permissions that fix_permissions.sh fixes.

fix_permissions.sh will

* Change group ownership to 'desi'.
* Ensure files and directories are readable by the desi group.
* Optionally, make files readable by apache for http access (with `-a` option).

and that's it.  In particular, no attempt is made to alter group write, user write, or any world permissions.

I need to test before merging, but wanted to get the discussion going.