### PR TITLE
Auto-generate API files

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,7 +10,10 @@ Change Log
 1.9.16 (unreleased)
 -------------------
 
-* No changes yet.
+* Add support for auto-generating API documentation via
+  :command:`python setup.py api` (PR `#131`_).
+
+.. _`#131`: https://github.com/desihub/desiutil/pull/131
 
 1.9.15 (2018-12-14)
 -------------------

--- a/py/desiutil/setup.py
+++ b/py/desiutil/setup.py
@@ -38,7 +38,7 @@ class DesiAPI(Command):
                     ('overwrite', 'o',
                      'Overwrite the existing API file.')]
     boolean_options = ['overwrite']
-    _exclude = ('_version.py',)
+    _exclude_file = ('_version.py',)
 
     def initialize_options(self):
         self.overwrite = False
@@ -48,15 +48,20 @@ class DesiAPI(Command):
         pass
 
     def run(self):
-        meta = self.distribution.metadata
-        n = meta.get_name()
+        n = self.distribution.metadata.get_name()
         productroot = find_version_directory(n)
         modules = []
         for dirpath, dirnames, filenames in walk(productroot):
-            d = dirpath.replace(productroot + '/', '')
+            if dirpath == productroot:
+                d = ''
+            else:
+                d = dirpath.replace(productroot + '/', '')
+            self.announce(d, level=DEBUG)
             for f in filenames:
                 mod = [n]
-                if f.endswith('.py') and f not in self._exclude and not self._test_file(d, f):
+                if f.endswith('.py') and f not in self._exclude_file and not self._test_file(d, f):
+                    if d:
+                        mod += d.split('/')
                     if f != '__init__.py':
                         mod.append(f.replace('.py', ''))
                     modules.append('.'.join(mod))

--- a/py/desiutil/setup.py
+++ b/py/desiutil/setup.py
@@ -12,8 +12,8 @@ from __future__ import absolute_import, division, print_function
 # unicode_literals.
 import re
 import unittest
-from os import environ
-from os.path import abspath, exists, isdir, isfile, join
+from os import environ, walk
+from os.path import abspath, basename, exists, isdir, isfile, join
 from sys import exit, version_info
 from setuptools import Command
 try:
@@ -23,10 +23,65 @@ except ImportError:
 # from setuptools.py31compat import unittest_main
 from setuptools.command.test import test as BaseTest
 from pkg_resources import _namespace_packages
-from distutils.log import INFO, WARN, ERROR
+from distutils.log import DEBUG, INFO, WARN, ERROR
 from .svn import version as svn_version
 from .git import version as git_version
 from .modules import configure_module, process_module, default_module
+
+
+class DesiAPI(Command):
+    """Generate an api.rst file.
+    """
+    description = "create/update doc/api.rst"
+    user_options = [('api=', 'a',
+                     'Set the name of the API file (default doc/api.rst).'),
+                    ('overwrite', 'o',
+                     'Overwrite the existing API file.')]
+    boolean_options = ['overwrite']
+    _exclude = ('_version.py',)
+
+    def initialize_options(self):
+        self.overwrite = False
+        self.api = join(abspath('.'), 'doc', 'api.rst')
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        meta = self.distribution.metadata
+        n = meta.get_name()
+        productroot = find_version_directory(n)
+        modules = []
+        for dirpath, dirnames, filenames in walk(productroot):
+            d = dirpath.replace(productroot + '/', '')
+            for f in filenames:
+                mod = [n]
+                if f.endswith('.py') and f not in self._exclude and not self._test_file(d, f):
+                    if f != '__init__.py':
+                        mod.append(f.replace('.py', ''))
+                    modules.append('.'.join(mod))
+                    self.announce('.'.join(mod), level=DEBUG)
+        self._print(n, modules)
+
+    def _print(self, name, modules):
+        lines = []
+        title = "{0} API".format(name)
+        lines = ['='*len(title), title, '='*len(title), '']
+        for m in sorted(modules):
+            lines += ['.. automodule:: {0}'.format(m), '    :members:', '']
+        if exists(self.api):
+            if self.overwrite:
+                self.announce("{0} will be overwritten!".format(self.api),
+                              level=WARN)
+            else:
+                self.announce("{0} already exists!".format(self.api),
+                              level=ERROR)
+                exit(1)
+        with open(self.api, 'w') as a:
+            a.write('\n'.join(lines))
+
+    def _test_file(self, d, f):
+        return basename(d) == 'test' or basename(d) == 'tests'
 
 
 class DesiModule(Command):

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from setuptools import setup, find_packages
 #
 # desiutil needs to import some of its own code.
 #
-sys.path.insert(int(sys.path[0] == ''),os.path.abspath('./py'))
-from desiutil.setup import DesiModule, DesiTest, DesiVersion, get_version
+sys.path.insert(int(sys.path[0] == ''), os.path.abspath('./py'))
+import desiutil.setup as ds
 #
 # Begin setup
 #
@@ -33,7 +33,7 @@ setup_keywords['url'] = 'https://github.com/desihub/desiutil'
 #
 # END OF SETTINGS THAT NEED TO BE CHANGED.
 #
-setup_keywords['version'] = get_version(setup_keywords['name'])
+setup_keywords['version'] = ds.get_version(setup_keywords['name'])
 #
 # Use README.rst as long_description.
 #
@@ -56,8 +56,12 @@ setup_keywords['requires'] = ['Python (>2.7.0)']
 setup_keywords['zip_safe'] = False
 setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('py')
-setup_keywords['package_dir'] = {'':'py'}
-setup_keywords['cmdclass'] = {'module_file': DesiModule, 'version': DesiVersion, 'test': DesiTest, 'sdist': DistutilsSdist}
+setup_keywords['package_dir'] = {'': 'py'}
+setup_keywords['cmdclass'] = {'module_file': ds.DesiModule,
+                              'version': ds.DesiVersion,
+                              'test': ds.DesiTest,
+                              'api': ds.DesiAPI,
+                              'sdist': DistutilsSdist}
 setup_keywords['test_suite']='{name}.test.{name}_test_suite.{name}_test_suite'.format(**setup_keywords)
 #
 # Autogenerate command-line scripts.


### PR DESCRIPTION
This PR closes #130, providing a mechanism to auto-generate Sphinx API files.

Examples:

* Generate `doc/api.rst` from scratch: `python setup.py api`
* Overwrite an existing `doc/api.rst` file: `python setup.py api --overwrite`
* Generate a *new* api file to compare with an existing file: `python setup.py api --api doc/new_api.rst`

I've tested this on desiutil itself, where it generated a document byte-for-byte identical to the existing api file, and also on desispec, where it found only minor differences.