### PR TITLE
unique plt.axes for test

### DIFF
--- a/py/desiutil/test/test_plots.py
+++ b/py/desiutil/test/test_plots.py
@@ -120,8 +120,10 @@ class TestPlots(unittest.TestCase):
         from ..plots import plot_slices
         x = np.random.rand(1000)
         y = np.random.randn(1000)
+        # Create new labels axes so test won't reuse gca from previous test
+        axis = plt.axes(label='test-plot-slices')
         # Run
-        ax_slices = plot_slices(x, y, 0., 1., 0.)
+        ax_slices = plot_slices(x, y, 0., 1., 0., axis=axis)
         ax_slices.set_ylabel('N sigma')
         ax_slices.set_xlabel('x')
         if 'TRAVIS_JOB_ID' not in os.environ:


### PR DESCRIPTION
This PR works around issue #134 where tests of `desiutil.plots.plot_slices` were blowing memory.  The problem came from calling `plot_slices` without an `axis` argument, in which case it uses `plt.gca()`.  Apparently the test was picking up the plot axes from a previous test that was leftover in plt.gca, and generating some corrupted plot that would blow memory when you try to save it.  Now the test generates its own clean axes to use.

Regardless of this "fix", I support getting rid of basemap, but this can get us back with running tests at NERSC.