### PR TITLE
Remove references to project/projectdirs

### DIFF
--- a/bin/user_metadata.sh
+++ b/bin/user_metadata.sh
@@ -36,7 +36,7 @@ user=$1
 date=$2
 uid=$(id -u ${user})
 gid=$(id -g ${group})
-root=/global/project/projectdirs/${group}/metadata
+root=/global/cfs/cdirs/${group}/metadata
 for f in 2 a; do
     grep -E "${uid}\|${desi}" ${root}/${date}.tlproject${f}.${group}.txt | \
         cut -d\| -f16 | \

--- a/bin/user_metadata.sh
+++ b/bin/user_metadata.sh
@@ -37,8 +37,8 @@ date=$2
 uid=$(id -u ${user})
 gid=$(id -g ${group})
 root=/global/cfs/cdirs/${group}/metadata
-for f in 2 a; do
-    grep -E "${uid}\|${desi}" ${root}/${date}.tlproject${f}.${group}.txt | \
+for filesystem in cfs tlprojecta; do
+    grep -E "${uid}\|${group}" ${root}/${date}.${filesystem}.${group}.txt | \
         cut -d\| -f16 | \
         sed 's$%2F$/$g' | \
         sed "s%.snapshots/${date}/%%g"

--- a/bin/user_metadata.sh
+++ b/bin/user_metadata.sh
@@ -38,7 +38,7 @@ uid=$(id -u ${user})
 gid=$(id -g ${group})
 root=/global/cfs/cdirs/${group}/metadata
 for filesystem in cfs tlprojecta; do
-    grep -E "${uid}\|${group}" ${root}/${date}.${filesystem}.${group}.txt | \
+    grep -E "${uid}\|${gid}" ${root}/${date}.${filesystem}.${group}.txt | \
         cut -d\| -f16 | \
         sed 's$%2F$/$g' | \
         sed "s%.snapshots/${date}/%%g"

--- a/bin/user_metadata.sh
+++ b/bin/user_metadata.sh
@@ -41,5 +41,6 @@ for filesystem in cfs tlprojecta; do
     grep -E "${uid}\|${gid}" ${root}/${date}.${filesystem}.${group}.txt | \
         cut -d\| -f16 | \
         sed 's$%2F$/$g' | \
-        sed "s%.snapshots/${date}/%%g"
+        sed "s%.snapshots/${date}/%%g" | \
+        sed "s%^/cfs%/global/cfs%g"
 done

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ Change Log
 2.0.2 (unreleased)
 ------------------
 
-* Update NERSC paths for CFS.
+* Update NERSC paths for CFS (PR `#137`_).
+
+.. _`#137`: https://github.com/desihub/desiutil/pull/137
 
 2.0.1 (2019-09-24)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Change Log
 2.0.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Update NERSC paths for CFS.
 
 2.0.1 (2019-09-24)
 ------------------

--- a/py/desiutil/data/census.yaml
+++ b/py/desiutil/data/census.yaml
@@ -9,7 +9,7 @@ configuration:
     # Mapping from primary filesystem to auxilliary filesystem.
     #
     filesystems:
-        /global/project/projectdirs: /global/projecta/projectdirs
+        /global/cfs/cdirs: /global/projecta/projectdirs
     #
     # Map group name to group ID.
     #
@@ -21,7 +21,7 @@ configuration:
 # unless overridden.
 #
 data:
-    # - root: /global/project/projectdirs/desi/spectro
+    # - root: /global/cfs/cdirs/desi/spectro
     #   category: DESI Data
     #   description: DESI raw and reduced data.
     #   group: desi
@@ -32,11 +32,11 @@ data:
     #         description: DESI reduced data
     #       - root: sim
     #         description: DESI simulated data
-    # - root: /global/project/projectdirs/desi/users
+    # - root: /global/cfs/cdirs/desi/users
     #   category: Collaboration Workspace
     #   description: Working space for individual users.
     #   group: desi
-    - root: /global/project/projectdirs/cosmo/data/legacysurvey
+    - root: /global/cfs/cdirs/cosmo/data/legacysurvey
       category: Imaging Data
       description: Released data from DECaLS/MzLS/BASS.
       group: cosmo
@@ -49,7 +49,7 @@ data:
             description: DECaLS DR3.0.
           - root: dr3.1
             description: DECaLS DR3.1.
-    - root: /global/project/projectdirs/cosmo/staging/decam
+    - root: /global/cfs/cdirs/cosmo/staging/decam
       category: Imaging Data
       description: DECaLS data.
       group: cosmo
@@ -72,7 +72,7 @@ data:
             description: DECam data in the DECaLS footprint in preparation for DR5.
           - root: Stacks_Aug14
             description: No idea what this is.
-    - root: /global/project/projectdirs/cosmo/staging/mosaicz
+    - root: /global/cfs/cdirs/cosmo/staging/mosaicz
       category: Imaging Data
       description: MzLS data.
       group: cosmo
@@ -81,7 +81,7 @@ data:
             description: MzLS data processed by NOAO CP.
           - root: MZLS_Raw
             description: MzLS raw data.
-    - root: /global/project/projectdirs/cosmo/staging/bok
+    - root: /global/cfs/cdirs/cosmo/staging/bok
       category: Imaging Data
       description: BASS data.
       group: cosmo
@@ -98,7 +98,7 @@ data:
             description: No idea what this is.
           - root: reduced
             description: BASS data processed by BASS.
-    - root: /global/project/projectdirs/cosmo/data/wise
+    - root: /global/cfs/cdirs/cosmo/data/wise
       category: Imaging Data
       description: WISE images.
       group: cosmo
@@ -113,11 +113,11 @@ data:
             description: Post-reactivation imaging?
           - root: postcryo
             description: Imaging without functioning cryostat?
-    - root: /global/project/projectdirs/cosmo/staging/wise/neowiser2/neowiser
+    - root: /global/cfs/cdirs/cosmo/staging/wise/neowiser2/neowiser
       category: Imaging Data
       description: Unmerged post-reactivation WISE imaging.
       group: cosmo
-    - root: /global/project/projectdirs/cosmo/data/unwise
+    - root: /global/cfs/cdirs/cosmo/data/unwise
       category: Imaging Data
       description: WISE full-resolution coadds.
       group: cosmo
@@ -130,11 +130,11 @@ data:
             description: Original unWISE coadds.
           - root: unwise-phot
             description: Original unWISE coadds (photometry?).
-    - root: /global/project/projectdirs/cosmo/staging/decam-public
+    - root: /global/cfs/cdirs/cosmo/staging/decam-public
       category: Non-DESI Data
       description: DECam data outside of the DESI footprint.
       group: cosmo
-    # - root: /global/project/projectdirs/cosmo/work
+    # - root: /global/cfs/cdirs/cosmo/work
     #   category: Collaboration Workspace
     #   description: Working space for individual users.
     #   group: cosmo

--- a/py/desiutil/setup.py
+++ b/py/desiutil/setup.py
@@ -99,8 +99,11 @@ class DesiModule(Command):
     def finalize_options(self):
         if self.modules is None:
             try:
-                self.modules = join('/project/projectdirs/desi/software/modules',
-                                    environ['NERSC_HOST'])
+                self.modules = join('/global/common/software/desi',
+                                    environ['NERSC_HOST'],
+                                    'desiconda',
+                                    'current',
+                                    'modulefiles')
             except KeyError:
                 try:
                     self.modules = join(environ['DESI_PRODUCT_ROOT'],

--- a/py/desiutil/test/make_testmaps.py
+++ b/py/desiutil/test/make_testmaps.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy.io import fits
 from time import time
 
-dustdir = "/project/projectdirs/desi/software/edison/dust/v0_1/maps"
+dustdir = "/global/cfs/cdirs/cosmo/data/dust/v0_1/maps"
 start = time()
 
 for pole in ["ngp", "sgp"]:

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -365,10 +365,10 @@ class TestInstall(unittest.TestCase):
             self.assertEqual(self.desiInstall.nersc_module_dir,
                              join(self.desiInstall.default_nersc_dir(n),
                                   "modulefiles"))
-        options = self.desiInstall.get_options(['--root', '/project/projectdirs/desi/test',
+        options = self.desiInstall.get_options(['--root', '/global/cfs/cdirs/desi/test',
                                                 'desiutil', '1.9.5'])
         self.assertEqual(self.desiInstall.nersc_module_dir,
-                         '/project/projectdirs/desi/test/modulefiles')
+                         '/global/cfs/cdirs/desi/test/modulefiles')
 
     def test_cleanup(self):
         """Test the cleanup stage of the install.


### PR DESCRIPTION
This PR removes references to project/projectdirs.  Most of this code is rarely used.

*Do not merge yet.*  We still need to figure out what the new name of the cfs metadata file will be.