### PR TITLE
Check for HOME directory

### DIFF
--- a/bin/fix_permissions.sh
+++ b/bin/fix_permissions.sh
@@ -26,7 +26,7 @@ function usage() {
 function run() {
     local vrb=$1
     local cmd=$2
-    [ "${vrb}" = "True" ] && echo "${cmd}"
+    ${vrb} && echo "${cmd}"
     ${cmd}
 }
 #
@@ -35,15 +35,15 @@ function run() {
 apacheACL=''
 apacheUID=48
 desiGID=desi
-test=False
-verbose=False
+test=/usr/bin/false
+verbose=/usr/bin/false
 while getopts ag:htv argname; do
     case ${argname} in
         a) apacheACL="u:${apacheUID}:rX" ;;
         g) desiGID=${OPTARG} ;;
         h) usage; exit 0 ;;
-        t) test=True; verbose=True ;;
-        v) verbose=True ;;
+        t) test=/usr/bin/true; verbose=/usr/bin/true ;;
+        v) verbose=/usr/bin/true ;;
         *) usage; exit 1 ;;
     esac
 done
@@ -84,12 +84,16 @@ if [ -z "${NERSC_HOST}" ]; then
     echo "Unable to determine NERSC environment.  Are you running this script at NERSC?" >&2
     exit 1
 fi
+if [ $(realpath ${directory}) = $(realpath ${HOME}) ]; then
+    echo "You are attempting to change the permissions of HOME=${HOME}, which is dangerous.  Aborting." >&2
+    exit 1
+fi
 #
 # Proceed with permission changes.
 #
 findbase="${find} ${directory} -user ${USER}"
-[ "${verbose}" = "True" ] && echo "Fixing permissions on ${directory} ..."
-if [ "${test}" = "True" ]; then
+${verbose} && echo "Fixing permissions on ${directory} ..."
+if ${test}; then
     run ${verbose} "${findbase} -not -group ${desiGID} -ls"
     run ${verbose} "${findbase} -type f -not -perm /g+r -ls"
     run ${verbose} "${findbase} -type d -not -perm -g+rxs -ls"
@@ -101,7 +105,7 @@ else
     #
     # Instruct chgrp & chmod to only report files that change.
     #
-    [ "${verbose}" = "True" ] && vflag='-c'
+    ${verbose} && vflag='-c'
     # Change group.
     run ${verbose} "${findbase} -not -group ${desiGID} -exec chgrp ${vflag} -h ${desiGID} {} ;"
     # Set group read access.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 3.0.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Protect against running :command:`fix_permissions.sh` in :envvar:`HOME`
+  (PR `#142`_).
+
+.. _`#142`: https://github.com/desihub/desiutil/pull/142
 
 3.0.0 (2020-04-15)
 ------------------


### PR DESCRIPTION
This PR prevents `fix_permissions.sh` from running in or on a `$HOME` directory.

I wanted to get this into master, but I don't think we need to cut a new tag for this.