### PR TITLE
add nightwatch, desimeter, and parallel make

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,12 @@ Change Log
 3.0.1 (unreleased)
 ------------------
 
+* Update package list in :mod:`desiutil.install`;
+  enable parallel :command:`make` (PR `#143`_).
 * Protect against running :command:`fix_permissions.sh` in :envvar:`HOME`
   (PR `#142`_).
 
+.. _`#143`: https://github.com/desihub/desiutil/pull/143
 .. _`#142`: https://github.com/desihub/desiutil/pull/142
 
 3.0.0 (2020-04-15)

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -29,11 +29,9 @@ known_products = {
     'desidatamodel': 'https://github.com/desihub/desidatamodel',
     'desidithering': 'https://github.com/desihub/desidithering',
     'desietc': 'https://github.com/desihub/desietc',
-    'desici': 'https://github.com/desihub/desici',
     'desilamps': 'https://github.com/desihub/desilamps',
     'desimeter': 'https://github.com/desihub/desimeter',
     'desimodel': 'https://github.com/desihub/desimodel',
-    'desimodules': 'https://github.com/desihub/desimodules',
     'desisim': 'https://github.com/desihub/desisim',
     'desisim-testdata': 'https://github.com/desihub/desisim-testdata',
     'desispec': 'https://github.com/desihub/desispec',
@@ -49,6 +47,7 @@ known_products = {
     'gcr-catalogs': 'https://github.com/desihub/gcr-catalogs',
     'imaginglss': 'https://github.com/desihub/imaginglss',
     'nightwatch': 'https://github.com/desihub/nightwatch',
+    'prospect': 'https://github.com/desihub/prospect',
     'quicksurvey_example': 'https://github.com/desihub/quicksurvey_example',
     'redrock': 'https://github.com/desihub/redrock',
     'redrock-templates': 'https://github.com/desihub/redrock-templates',
@@ -58,17 +57,10 @@ known_products = {
     'surveysim': 'https://github.com/desihub/surveysim',
     'teststand': 'https://github.com/desihub/teststand',
     'tilepicker': 'https://github.com/desihub/tilepicker',
-    'two_percent_DESI': 'https://github.com/desihub/two_percent_DESI',
     'simqso': 'https://github.com/imcgreer/simqso',
-    'speclite': 'https://github.com/dkirkby/speclite',
-    'bbspecsim': 'https://desi.lbl.gov/svn/code/spectro/bbspecsim',
-    'desiAdmin': 'https://desi.lbl.gov/svn/code/tools/desiAdmin',
-    'dspecsim': 'https://desi.lbl.gov/svn/code/spectro/dspecsim',
-    'elg_deep2': 'https://desi.lbl.gov/svn/code/targeting/elg_deep2',
     'plate_layout': 'https://desi.lbl.gov/svn/code/focalplane/plate_layout',
     'positioner_control':
         'https://desi.lbl.gov/svn/code/focalplane/positioner_control',
-    'templates': 'https://desi.lbl.gov/svn/code/spectro/templates',
     }
 
 

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -31,6 +31,7 @@ known_products = {
     'desietc': 'https://github.com/desihub/desietc',
     'desici': 'https://github.com/desihub/desici',
     'desilamps': 'https://github.com/desihub/desilamps',
+    'desimeter': 'https://github.com/desihub/desimeter',
     'desimodel': 'https://github.com/desihub/desimodel',
     'desimodules': 'https://github.com/desihub/desimodules',
     'desisim': 'https://github.com/desihub/desisim',
@@ -47,6 +48,7 @@ known_products = {
     'fiberassign': 'https://github.com/desihub/fiberassign',
     'gcr-catalogs': 'https://github.com/desihub/gcr-catalogs',
     'imaginglss': 'https://github.com/desihub/imaginglss',
+    'nightwatch': 'https://github.com/desihub/nightwatch',
     'quicksurvey_example': 'https://github.com/desihub/quicksurvey_example',
     'redrock': 'https://github.com/desihub/redrock',
     'redrock-templates': 'https://github.com/desihub/redrock-templates',
@@ -845,7 +847,7 @@ class DesiInstall(object):
                 if 'src' in self.build_type:
                     command = ['make', '-C', 'src', 'all']
                 else:
-                    command = ['make', 'install']
+                    command = ['make', '-j', '8', 'install']
                 self.log.debug(' '.join(command))
                 if self.options.test:
                     self.log.debug("Test Mode.  Skipping 'make install'.")

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -174,23 +174,23 @@ class TestInstall(unittest.TestCase):
         url = self.desiInstall.identify_branch()
         self.assertEqual(url,
                          'https://github.com/desihub/desiutil.git')
-        options = self.desiInstall.get_options(['desiAdmin', '1.0.0'])
+        options = self.desiInstall.get_options(['plate_layout', '1.0.0'])
         out = self.desiInstall.get_product_version()
         url = self.desiInstall.identify_branch()
         self.assertEqual(url,
-                         ('https://desi.lbl.gov/svn/code/tools/desiAdmin/' +
+                         ('https://desi.lbl.gov/svn/code/focalplane/plate_layout/' +
                           'tags/1.0.0'))
-        options = self.desiInstall.get_options(['desiAdmin', 'trunk'])
+        options = self.desiInstall.get_options(['plate_layout', 'trunk'])
         out = self.desiInstall.get_product_version()
         url = self.desiInstall.identify_branch()
         self.assertEqual(url,
-                         'https://desi.lbl.gov/svn/code/tools/desiAdmin/trunk')
-        options = self.desiInstall.get_options(['desiAdmin',
+                         'https://desi.lbl.gov/svn/code/focalplane/plate_layout/trunk')
+        options = self.desiInstall.get_options(['plate_layout',
                                                 'branches/testing'])
         out = self.desiInstall.get_product_version()
         url = self.desiInstall.identify_branch()
         self.assertEqual(url,
-                         ('https://desi.lbl.gov/svn/code/tools/desiAdmin/' +
+                         ('https://desi.lbl.gov/svn/code/focalplane/plate_layout/' +
                           'branches/testing'))
 
     def test_verify_url(self):
@@ -206,7 +206,7 @@ class TestInstall(unittest.TestCase):
         message = ("Error {0:d} querying GitHub URL: {1}.".format(
                    404, self.desiInstall.product_url))
         self.assertEqual(str(cm.exception), message)
-        options = self.desiInstall.get_options(['-v', 'desiAdmin', 'trunk'])
+        options = self.desiInstall.get_options(['-v', 'plate_layout', 'trunk'])
         out = self.desiInstall.get_product_version()
         url = self.desiInstall.identify_branch()
         self.desiInstall.verify_url(svn='echo')


### PR DESCRIPTION
This PR adds nightwatch and desimeter to the list of known packages, and adds `-j 8` to the `make install` command for compiled codes so that they compile faster in parallel (spexec in particular).

Note: nightwatch doesn't actually support `python setup.py install` yet, but this gets a placeholder ready in desiInstall for if/when nightwatch is ready to be installed.