### PR TITLE
Replace python setup.py test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,10 +92,11 @@ matrix:
 #     - python -c 'import setuptools; print(setuptools.__version__)'
 
 install:
+    - pip install -U pip
     - if [[ "${MAIN_CMD}" == pycodestyle ]]; then pip install pycodestyle; fi
     - if [[ "${MAIN_CMD}" == sphinx-build* ]]; then pip install Sphinx; fi
-    - if [[ "${SETUP_CMD}" == '--cov' ]]; then pip install pytest-cov coveralls; fi
     - if [[ "${MAIN_CMD}" == pytest ]]; then pip install -r requirements.txt; fi
+    - if [[ "${SETUP_CMD}" == '--cov' ]]; then pip install pytest-cov coveralls; fi
     # - if [[ "${MAIN_CMD}" == python* || "${MAIN_CMD}" == coverage* ]]; then pip install -r requirements.txt; fi
     - if [[ -n "${ASTROPY_VERSION}" ]]; then pip install -U "astropy${ASTROPY_VERSION}"; fi
 
@@ -103,4 +104,4 @@ script:
     - $MAIN_CMD $SETUP_CMD
 
 after_success:
-    - if [[ "${MAIN_CMD}" == coverage* ]]; then coveralls; fi
+    - if [[ "${SETUP_CMD}" == '--cov' ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - MAIN_CMD='python -m unittest'
-        - SETUP_CMD='discover -t py -v desiutil.test'
+        - MAIN_CMD='pytest'
+        - SETUP_CMD=''
+        # - MAIN_CMD='python -m unittest'
+        # - SETUP_CMD='discover -t py -v desiutil.test'
     matrix:
         # - SETUP_CMD='egg_info'
         # - SETUP_CMD='bdist_egg'
@@ -63,7 +65,7 @@ matrix:
         # Coverage test, pass the results to coveralls.
         - os: linux
           python: 3.6
-          env: MAIN_CMD='coverage run -m unittest'
+          env: SETUP_CMD='--cov'
 
         - os: linux
           python: 3.6
@@ -92,8 +94,9 @@ matrix:
 install:
     - if [[ "${MAIN_CMD}" == pycodestyle ]]; then pip install pycodestyle; fi
     - if [[ "${MAIN_CMD}" == sphinx-build* ]]; then pip install Sphinx; fi
-    - if [[ "${MAIN_CMD}" == coverage* ]]; then pip install coverage coveralls; fi
-    - if [[ "${MAIN_CMD}" == python* || "${MAIN_CMD}" == coverage* ]]; then pip install -r requirements.txt; fi
+    - if [[ "${SETUP_CMD}" == '--cov' ]]; then pip install pytest-cov coveralls; fi
+    - if [[ "${MAIN_CMD}" == pytest ]]; then pip install -r requirements.txt; fi
+    # - if [[ "${MAIN_CMD}" == python* || "${MAIN_CMD}" == coverage* ]]; then pip install -r requirements.txt; fi
     - if [[ -n "${ASTROPY_VERSION}" ]]; then pip install -U "astropy${ASTROPY_VERSION}"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - MAIN_CMD='python setup.py'
+        - MAIN_CMD='python -m unittest'
     matrix:
-        - SETUP_CMD='egg_info'
-        - SETUP_CMD='bdist_egg'
-        - SETUP_CMD='test'
+        # - SETUP_CMD='egg_info'
+        # - SETUP_CMD='bdist_egg'
+        - SETUP_CMD='discover -t py -v desiutil.test'
 
 matrix:
     # Don't wait for allowed failures.
@@ -58,20 +58,20 @@ matrix:
         # runs for a long time
         - os: linux
           python: 3.6
-          env: SETUP_CMD='build_sphinx --warning-is-error'
+          env: MAIN_CMD='sphinx-build' SETUP_CMD='-W --keep-going -b html doc doc/_build/html'
 
         # Coverage test, pass the results to coveralls.
         - os: linux
           python: 3.6
-          env: MAIN_CMD='coverage' SETUP_CMD='run --source=desiutil setup.py test'
+          env: MAIN_CMD='coverage run -m unittest'
 
         - os: linux
           python: 3.6
-          env: SETUP_CMD='test' ASTROPY_VERSION='>=4.0'
+          env: ASTROPY_VERSION='>=4.0'
 
         - os: linux
           python: 3.6
-          env: SETUP_CMD='test' ASTROPY_VERSION='<4.0'
+          env: ASTROPY_VERSION='<4.0'
 
         # Experimental OS X test.
         # As of March 2017, Python builds on OS X are not available.
@@ -90,14 +90,14 @@ matrix:
 #     - python -c 'import setuptools; print(setuptools.__version__)'
 
 install:
-    - if [[ "${MAIN_CMD}" == 'pycodestyle' ]]; then pip install pycodestyle; fi
-    - if [[ "${SETUP_CMD}" == build_sphinx* ]]; then pip install Sphinx; fi
-    - if [[ "${MAIN_CMD}" == 'coverage' ]]; then pip install coverage coveralls; fi
-    - if [[ "${SETUP_CMD}" == 'test' || $MAIN_CMD == 'coverage' ]]; then pip install -r requirements.txt; fi
+    - if [[ "${MAIN_CMD}" == pycodestyle ]]; then pip install pycodestyle; fi
+    - if [[ "${MAIN_CMD}" == sphinx-build* ]]; then pip install Sphinx; fi
+    - if [[ "${MAIN_CMD}" == coverage* ]]; then pip install coverage coveralls; fi
+    - if [[ "${MAIN_CMD}" == python* || "${MAIN_CMD}" == coverage* ]]; then pip install -r requirements.txt; fi
     - if [[ -n "${ASTROPY_VERSION}" ]]; then pip install -U "astropy${ASTROPY_VERSION}"; fi
 
 script:
     - $MAIN_CMD $SETUP_CMD
 
 after_success:
-    - if [[ $MAIN_CMD == 'coverage' ]]; then coveralls; fi
+    - if [[ "${MAIN_CMD}" == coverage* ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - MAIN_CMD='python -m unittest'
+        - SETUP_CMD='discover -t py -v desiutil.test'
     matrix:
         # - SETUP_CMD='egg_info'
         # - SETUP_CMD='bdist_egg'
-        - SETUP_CMD='discover -t py -v desiutil.test'
 
 matrix:
     # Don't wait for allowed failures.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ Change Log
 3.0.1 (unreleased)
 ------------------
 
+* Start migrating to use :command:`pytest` to run tests instead of
+  :command:`python setup.py test` (PR `#145`_).
 * Update package list in :mod:`desiutil.install`;
   enable parallel :command:`make` (PR `#143`_).
 * Protect against running :command:`fix_permissions.sh` in :envvar:`HOME`
   (PR `#142`_).
 
+.. _`#145`: https://github.com/desihub/desiutil/pull/145
 .. _`#143`: https://github.com/desihub/desiutil/pull/143
 .. _`#142`: https://github.com/desihub/desiutil/pull/142
 

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -13,7 +13,7 @@ from logging import getLogger
 from pkg_resources import resource_filename
 from ..log import DEBUG
 from ..install import DesiInstall, DesiInstallException, dependencies
-from .test_log import TestHandler
+from .test_log import NullMemoryHandler
 
 
 class TestInstall(unittest.TestCase):
@@ -37,7 +37,7 @@ class TestInstall(unittest.TestCase):
             h = root_logger.handlers[0]
             fmt = h.formatter
             root_logger.removeHandler(h)
-        mh = TestHandler()
+        mh = NullMemoryHandler()
         mh.setFormatter(fmt)
         root_logger.addHandler(mh)
         self.desiInstall.log.setLevel(DEBUG)

--- a/py/desiutil/test/test_log.py
+++ b/py/desiutil/test/test_log.py
@@ -14,7 +14,7 @@ from ..log import (DEBUG, INFO, WARNING, ERROR, CRITICAL,
                    _desiutil_log_root)
 
 
-class TestHandler(MemoryHandler):
+class NullMemoryHandler(MemoryHandler):
     """Capture log messages in memory.
     """
     def __init__(self, capacity=1000000, flushLevel=CRITICAL):
@@ -86,7 +86,7 @@ class TestLog(unittest.TestCase):
             h = root_logger.handlers[0]
             fmt = h.formatter
             root_logger.removeHandler(h)
-        mh = TestHandler()
+        mh = NullMemoryHandler()
         mh.setFormatter(fmt)
         root_logger.addHandler(mh)
         return logger


### PR DESCRIPTION
This PR fixes #144 by migrating tests to use `pytest` and `sphinx-build` instead of `python setup.py test` and `python setup.py build_sphinx`.

I'd like to issue a new tag after merging, so this can make it into a 20.6 release.