### PR TITLE
Use https to avoid redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 htmlcov
 .coverage
 py/desiutil/.cache
+.pytest_cache
 
 # Sphinx
 doc/api

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -200,7 +200,7 @@ class TestInstall(unittest.TestCase):
         out = self.desiInstall.get_product_version()
         url = self.desiInstall.identify_branch()
         self.assertTrue(self.desiInstall.verify_url())
-        self.desiInstall.product_url = 'http://desi.lbl.gov/no/such/place'
+        self.desiInstall.product_url = 'https://desi.lbl.gov/no/such/place'
         with self.assertRaises(DesiInstallException) as cm:
             self.desiInstall.verify_url()
         message = ("Error {0:d} querying GitHub URL: {1}.".format(


### PR DESCRIPTION
This PR fixes #147 

The good news is that it appears http is now being comprehensively forwarded to https for desi.lbl.gov.  But the test was interpreting a redirect as a successful connection when it should have been a failure.