### PR TITLE
pin healpy requirement for old astropy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ setuptools
 requests
 pyyaml
 astropy==2.0.16
-healpy
+healpy==1.12.9
 matplotlib


### PR DESCRIPTION
Recent healpy is incompatible with astropy 2.x but doesn't properly reflect that in its package requirements.  Pin to an old version of healpy for travis tests for now.  desispec and desisim had the same problem which was fixed by pinning their version of healpy for travis testing.

This is a temporary fix.  The plan going forward is:
  * get all our packages working with astropy=4.x (and other updated packages) while still supporting astropy=2.x.  I'm actively working on this.
  * make set of tags and a software release
  * drop support for astropy 2.x for future work and update tests, requirements.txt etc to use more recent version.

