### PR TITLE
desiconda normpath and fix 'is not' SyntaxWarning

### DIFF
--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -539,7 +539,7 @@ class DesiInstall(object):
             The DESI+Anaconda version.
         """
         try:
-            desiconda = os.environ['DESICONDA']
+            desiconda = os.path.normpath(os.environ['DESICONDA'])
         except KeyError:
             return 'current'
         try:

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -51,7 +51,7 @@ def init_modules(moduleshome=None, method=False, command=False):
             with open(dot_modulespath, 'r') as f:
                 for line in f.readlines():
                     line = re.sub("#.*$", '', line.strip())
-                    if line is not '':
+                    if line != '':
                         path.append(line)
             os.environ['MODULEPATH'] = ':'.join(path)
         modulerc = os.path.join(moduleshome, 'init', 'modulerc')
@@ -60,7 +60,7 @@ def init_modules(moduleshome=None, method=False, command=False):
             with open(modulerc, 'r') as f:
                 for line in f.readlines():
                     line = re.sub("#.*$", '', line.strip())
-                    if line is not '' and line.startswith('module use'):
+                    if line != '' and line.startswith('module use'):
                         p = os.path.expanduser(line.replace('module use ', '').strip())
                         path.append(p)
             os.environ['MODULEPATH'] = ':'.join(path)


### PR DESCRIPTION
This PR makes desiInstall more robust to a non-standard `$DESICONDA` by filtering it through `os.path.normpath` before parsing it.  In particular the previous version interpreted `/global/common/software/desi/cori/desiconda/20200801-1.4.0-spec//conda` as version '' (blank) instead of '20200801-1.4.0-spec' due to the double slash.

It also fixes a py3.8 SyntaxWarning about using `is not` instead `!=` when comparing a variable to a literal (prior syntax happens to work with cpython, but isn't guaranteed by the language syntax).  `blat is not None` is still ok, but `blat is not ""` raises a SyntaxWarning in py3.8.