### PR TITLE
add Timer class to standardize algorithm timing reports

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -55,3 +55,6 @@ desiutil API
 
 .. automodule:: desiutil.svn
     :members:
+
+.. automodule:: desiutil.timer
+    :members:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ Change Log
 3.0.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Add `Timer` class to standardize timing reports (PR `#151`_).
+
+.. _`#151`: https://github.com/desihub/desiutil/pull/151
 
 3.0.3 (2020-08-04)
 ------------------

--- a/py/desiutil/test/test_timer.py
+++ b/py/desiutil/test/test_timer.py
@@ -1,0 +1,77 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.timer.
+"""
+import unittest
+import json
+import time
+from ..timer import Timer
+
+class TestTimer(unittest.TestCase):
+    """Test desiutil.timer
+    """
+
+    def test_timer(self):
+        """Basic timer functionality"""
+        t = Timer()
+        t.start('blat')
+
+        #- Context manager is syntatic sugar for timing simple steps
+        with t.time('blat.input'):
+            time.sleep(0.1)
+
+        #- Or use full start/stop
+        t.start('blat.algorithm')
+        time.sleep(0.1)
+        t.stop('blat.algorithm')
+
+        with t.time('blat.output'):
+            time.sleep(0.1)
+
+        #- Get timing report, which should be json parse-able
+        timing_report = t.report()
+        timing = json.loads(timing_report)
+
+        for name in ['blat', 'blat.input', 'blat.algorithm', 'blat.output']:
+            self.assertIn(name, timing.keys(), f'Missing timing report for name')
+            self.assertIn('start', timing[name].keys(), f'{name} missing start time')
+            self.assertIn('stop', timing[name].keys(), f'{name} missing stop time')
+            self.assertIn('duration', timing[name].keys(), f'{name} missing duration')
+
+        #- Subtests should approximately add up to wrapper test
+        t0 = timing['blat']['duration']
+        t1 = timing['blat.input']['duration'] + \
+             timing['blat.algorithm']['duration'] + \
+             timing['blat.output']['duration']
+
+        self.assertAlmostEqual(t0, t1, 1)
+
+
+    def test_timer_misuse(self):
+        """Mis-use of timer should not be fatal"""
+        t = Timer()
+
+        #- Restarting a timer prints warning but isn't fatal
+        t.start('blat')
+        t.start('blat')
+
+        #- Stopping a non-existing timer prints error but isn't fatal
+        t.stop('foo')
+
+        #- Stop a timer twice
+        t.start('bar')
+        t.stop('bar')
+        t.stop('bar')
+
+        #- Getting a report stops timers
+        self.assertNotIn('stop', t.timers['blat'].keys())
+        timing_report = t.report()
+        self.assertIn('stop', t.timers['blat'].keys())
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m desiutil.test.test_timer
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desiutil/test/test_timer.py
+++ b/py/desiutil/test/test_timer.py
@@ -46,6 +46,23 @@ class TestTimer(unittest.TestCase):
 
         self.assertAlmostEqual(t0, t1, 1)
 
+    def test_stopall(self):
+        """Test stopping a batch of timers"""
+
+        t = Timer()
+        t.start('blat')
+        t.start('foo')
+        t.start('bar')
+
+        t.stop('blat')
+        self.assertIn('stop', t.timers['blat'].keys())
+        self.assertNotIn('stop', t.timers['foo'].keys())
+        self.assertNotIn('stop', t.timers['bar'].keys())
+
+        t.stopall()
+        self.assertIn('stop', t.timers['blat'].keys())
+        self.assertIn('stop', t.timers['foo'].keys())
+        self.assertIn('stop', t.timers['bar'].keys())
 
     def test_timer_misuse(self):
         """Mis-use of timer should not be fatal"""

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -1,0 +1,125 @@
+"""
+timer: standardizing reporting of algorithm and I/O timing
+
+The `timer.Timer` class is intended for reporting timing of events that
+take seconds to minutes; it is not intended for detailed profiling.  Example::
+
+    from desiutil.timer import Timer
+    t = Timer()
+    t.start('blat')
+
+    #- Use context manager for timing simple steps, e.g. one-liners
+    with t.time('blat.input'):
+        stuff = io.read(filename)
+
+    #- Or use full start/stop if you prefer
+    t.start('blat.algorithm')
+    results = calculate(stuff)
+    t.stop('blat.algorithm')
+
+    with t.time('blat.output'):
+        io.write(results)
+
+    #- Stop outer timer; Note that named timers can be nested or interleaved
+    t.stop('blat')
+
+    #- Print a json report of the timing
+    print(t.report())
+"""
+
+import traceback
+import time
+import datetime
+import json
+import copy
+import os.path
+from contextlib import contextmanager
+
+class Timer(object):
+    """
+    A basic timer class for standardizing reporting of algorithm and I/O timing
+    
+    TIMER:<START|STOP>:<filename>:<lineno>:<funcname>: <message>
+    """
+    
+    def __init__(self):
+        self.timers = dict()
+    
+    def _prefix(self, step):
+        """
+        Return standard prefix string for timer reporting
+        
+        Args:
+            step (str): timing step, e.g. "START" or "STOP"
+        """
+        stack = traceback.extract_stack()
+        #- Walk backwards in stack to find first caller not from this file
+        #- and not contextlib.py
+        #- (exact index depends on whether context manager was used or not)
+        thisfile = os.path.normpath(__file__)
+        for caller in stack[-1::-1]:
+            if os.path.normpath(caller.filename) != thisfile and \
+               os.path.basename(caller.filename) != 'contextlib.py':
+                break
+        
+        filename = os.path.basename(caller.filename)
+        return f"TIMER-{step}:{filename}:{caller.lineno}:{caller.name}:"
+    
+    def start(self, name):
+        """Start a timer `name` (str)"""
+        # timestamp = datetime.datetime.now().replace(microsecond=0).isoformat()        
+        timestamp = datetime.datetime.now().isoformat()        
+        if name in self.timers:
+            print(self._prefix('WARNING'), f'Restarting {name} at {timestamp}')
+        
+        print(self._prefix('START'), f'Starting {name} at {timestamp}')
+        self.timers[name] = dict(start=time.time())
+    
+    def stop(self, name):
+        """Stop timer `name` (str)"""
+        #- non-fatal ERROR: trying to stop a timer that wasn't started
+        timestamp = datetime.datetime.now().isoformat()        
+        if name not in self.timers:
+            print(self._prefix('ERROR'), f'Tried to stop non-existent timer {name} at {timestamp}')
+            return -1.0
+
+        #- WARNING: resetting the stop time of a timer that was already stopped
+        if 'stop' in self.timers[name]:
+            print(self._prefix('WARNING'), f'Resetting stop time of {name} at {timestamp}')
+        
+        #- All clear; proceed
+        self.timers[name]['stop'] = time.time()
+        dt = self.timers[name]['stop'] - self.timers[name]['start']
+        self.timers[name]['duration'] = dt
+        print(self._prefix('STOP'), f'Stopping {name} at {timestamp}; duration {dt:.2f} seconds')
+        return dt
+
+    @contextmanager
+    def time(self, name):
+        self.start(name)
+        try:
+            yield
+        finally:
+            return self.stop(name)
+
+    def report(self):
+        """
+        Return a json dump of self.timers, with start/stop as ISO-8601 strings
+        
+        Implicitly stops any timers that are still running
+        """
+        #- First stop any running timers
+        for name in self.timers:
+            if 'stop' not in self.timers[name]:
+                self.stop(name)
+        
+        #- Now replace time-since-epoch float with ISO-8601 str using copy
+        t = copy.deepcopy(self.timers)
+        for name in t:            
+            for key in ['start', 'stop']:
+                tx = datetime.datetime.fromtimestamp(t[name][key]).isoformat()
+                t[name][key] = tx
+
+        return json.dumps(t, indent=2)
+        
+

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -1,5 +1,11 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
 """
-timer: standardizing reporting of algorithm and I/O timing
+==============
+desiutil.timer
+==============
+
+Provides `Timer` class to standardize reporting of algorithm and I/O timing.
 
 The `timer.Timer` class is intended for reporting timing of events that
 take seconds to minutes; it is not intended for detailed profiling.  Example::
@@ -66,7 +72,7 @@ class Timer(object):
         return f"TIMER-{step}:{filename}:{caller.lineno}:{caller.name}:"
     
     def start(self, name):
-        """Start a timer `name` (str)"""
+        """Start a timer `name` (str); prints TIMER-START message"""
         # timestamp = datetime.datetime.now().replace(microsecond=0).isoformat()        
         timestamp = datetime.datetime.now().isoformat()        
         if name in self.timers:
@@ -76,7 +82,7 @@ class Timer(object):
         self.timers[name] = dict(start=time.time())
     
     def stop(self, name):
-        """Stop timer `name` (str)"""
+        """Stop timer `name` (str); prints TIMER-STOP message"""
         #- non-fatal ERROR: trying to stop a timer that wasn't started
         timestamp = datetime.datetime.now().isoformat()        
         if name not in self.timers:
@@ -96,6 +102,21 @@ class Timer(object):
 
     @contextmanager
     def time(self, name):
+        """Context manager for timing a code snippet.
+
+        Usage::
+
+            t = Timer()
+            with t.time('blat'):
+                blat()
+
+        is equivalent to::
+
+            t = Timer()
+            t.start('blat')
+            blat()
+            t.stop('blat')
+        """
         self.start(name)
         try:
             yield

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -7,8 +7,15 @@ desiutil.timer
 
 Provides `Timer` class to standardize reporting of algorithm and I/O timing.
 
-The `timer.Timer` class is intended for reporting timing of events that
-take seconds to minutes; it is not intended for detailed profiling.  Example::
+The `timer.Timer` class is intended for reporting timing of high-level events
+that take seconds to minutes, e.g. reporting the timing for the input,
+calculation, and output steps of a spectroscopic pipeline script.
+It is *not* intended for detailed profiling of every possible function for
+the purposes of optimization studies (use python cProfile for that);
+nor is it intended for timing small functions deep in the call stack that
+could result in N>>1 messages when run in parallel.
+
+Example::
 
     from desiutil.timer import Timer
     t = Timer()
@@ -31,6 +38,12 @@ take seconds to minutes; it is not intended for detailed profiling.  Example::
 
     #- Print a json report of the timing
     print(t.report())
+
+This module has the philosophy that adding timing information should not
+crash your code, even if the timer is used incorrectly, e.g. starting or
+stopping a timer multiple times, stopping a timer that was never started,
+or forgetting to stop a timer before asking for a report.  These print
+additional warnings or error messages, but don't raise exceptions.
 """
 
 import traceback
@@ -49,12 +62,21 @@ class Timer(object):
     """
     
     def __init__(self):
+        """
+        Create a Timer object.
+
+        Timing info is kept in `self.timers` dict
+
+        timers[name]['start'] = start time (seconds since Epoch)
+        timers[name]['start'] = stop time (seconds since Epoch)
+        timers[name]['duration'] = stop - start (seconds)
+        """
         self.timers = dict()
     
     def _prefix(self, step):
         """
         Return standard prefix string for timer reporting
-        
+
         Args:
             step (str): timing step, e.g. "START" or "STOP"
         """
@@ -72,17 +94,40 @@ class Timer(object):
         return f"TIMER-{step}:{filename}:{caller.lineno}:{caller.name}:"
     
     def start(self, name):
-        """Start a timer `name` (str); prints TIMER-START message"""
+        """Start a timer `name` (str); prints TIMER-START message
+
+        Args:
+            name (str): name of timer to stop
+
+        If `name` is started multiple times, the last call to `.start` is used
+        for the timestamp.
+        """
         # timestamp = datetime.datetime.now().replace(microsecond=0).isoformat()        
         timestamp = datetime.datetime.now().isoformat()        
         if name in self.timers:
             print(self._prefix('WARNING'), f'Restarting {name} at {timestamp}')
         
         print(self._prefix('START'), f'Starting {name} at {timestamp}')
+        # import desiutil.log
+        # log = desiutil.log.get_logger()
+        # log.info(f'Starting {name} at {timestamp}')
         self.timers[name] = dict(start=time.time())
     
     def stop(self, name):
-        """Stop timer `name` (str); prints TIMER-STOP message"""
+        """Stop timer `name` (str); prints TIMER-STOP message
+
+        Args:
+            name (str): name of timer to stop
+
+        Returns time since start in seconds, or -1.0 if `name` wasn't started
+
+        Note: this purposefully does *not* raise an exception if called with
+        a `name` that wasn't started, under the philosophy that adding timing
+        statements shouldn't crash code, even if used incorrectly.
+
+        If a timer is stopped multiple times, the final stop and duration
+        are timestamped as the last call to `Timer.stop`.
+        """
         #- non-fatal ERROR: trying to stop a timer that wasn't started
         timestamp = datetime.datetime.now().isoformat()        
         if name not in self.timers:
@@ -98,6 +143,9 @@ class Timer(object):
         dt = self.timers[name]['stop'] - self.timers[name]['start']
         self.timers[name]['duration'] = dt
         print(self._prefix('STOP'), f'Stopping {name} at {timestamp}; duration {dt:.2f} seconds')
+        # import desiutil.log
+        # log = desiutil.log.get_logger()
+        # log.info(f'Stopping {name} at {timestamp}; duration {dt:.2f} seconds')
         return dt
 
     @contextmanager
@@ -123,24 +171,39 @@ class Timer(object):
         finally:
             return self.stop(name)
 
+    def timer_seconds2iso8601(self):
+        """
+        Return copy `self.timers` with start/stop as ISO-8601 strings
+
+        Does *not* stop any running timers.
+        """
+        t = copy.deepcopy(self.timers)
+        for name in t:
+            for key in ['start', 'stop']:
+                if key in t[name]:
+                    iso8601 = datetime.datetime.fromtimestamp(t[name][key]).isoformat()
+                    t[name][key] = iso8601
+
+        return t
+
     def report(self):
         """
         Return a json dump of self.timers, with start/stop as ISO-8601 strings
-        
+
         Implicitly stops any timers that are still running
+
+        Use `Timer.timers` for access as a dictionary, where start/stop are
+        seconds elapsed since the epoch (1970-01-01T00:00:00 UTC on Unix).
         """
         #- First stop any running timers
         for name in self.timers:
             if 'stop' not in self.timers[name]:
                 self.stop(name)
-        
-        #- Now replace time-since-epoch float with ISO-8601 str using copy
-        t = copy.deepcopy(self.timers)
-        for name in t:            
-            for key in ['start', 'stop']:
-                tx = datetime.datetime.fromtimestamp(t[name][key]).isoformat()
-                t[name][key] = tx
 
+        #- Get copy of self.timers converted to ISO-8601
+        t = self.timer_seconds2iso8601()
+
+        #- Convert to human-friendly formatted json string
         return json.dumps(t, indent=2)
         
 


### PR DESCRIPTION
This PR adds a lightweight `desiutil.timer.Timer` utility class to standardize timing reports of pipeline steps.  It is intended for steps that take seconds to minutes, not for high-resolution profile timing of N>>1 functions.  e.g. in desispec pipeline steps I plan to track python startup, initial input, algorithm, and final output times.

Example usage with either `Timer.start(name)` and `Timer.stop(name)` or with a context manager `Timer.time(name)`:
```python
import time
from desiutil.timer import Timer
t = Timer()

# Start a named timer
t.start('blat')
# do something...
time.sleep(0.1)

# Use a context manager to time a small snippet
with t.time('input'):
    # stuff = io.read(filename)
    time.sleep(0.1)

# do some more stuff
time.sleep(0.1)

# stop the blat timer
t.stop('blat')

# Get a json-parseable report
print(t.report())
```
Note that named timers can be nested and interleaved.  If run as a script `blat.py` this would produce:
```
TIMER-START:blat.py:6:<module>: Starting blat at 2020-09-09T12:05:36.884383
TIMER-START:blat.py:11:<module>: Starting input at 2020-09-09T12:05:36.989992
TIMER-STOP:blat.py:13:<module>: Stopping input at 2020-09-09T12:05:37.091668; duration 0.10 seconds
TIMER-STOP:blat.py:19:<module>: Stopping blat at 2020-09-09T12:05:37.194143; duration 0.31 seconds
{
  "blat": {
    "start": "2020-09-09T12:05:36.884723",
    "stop": "2020-09-09T12:05:37.194197",
    "duration": 0.30947399139404297
  },
  "input": {
    "start": "2020-09-09T12:05:36.991274",
    "stop": "2020-09-09T12:05:37.091691",
    "duration": 0.1004171371459961
  }
}
```

Implementation detail: this does *not* use the `desiutil.log` logger, since I want the filename and line numbers to match the caller of the timer, not the line numbers within the `timer.py`, which is what would appear if `Timer` was calling `log.info()` etc.

The code is also intended to be robust to misuse, e.g. re-starting a named timer that is already running, stopping a timer that was never started, or stopping a timer twice.  These produce warning/error messages, but don't crash.

Review requested from @weaverba137 as the gatekeeper of desiutil, and comments welcome from @akremin @julienguy @dmargala @lastephey or any others who have recently been thinking about what would be useful for more standardized timing reports.