### PR TITLE
more Timer functionality

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,10 @@ Change Log
 3.0.4 (unreleased)
 ------------------
 
-* Add `Timer` class to standardize timing reports (PR `#151`_).
+* Add `Timer` class to standardize timing reports (PRs `#151`_, `#152`_).
 
 .. _`#151`: https://github.com/desihub/desiutil/pull/151
+.. _`#152`: https://github.com/desihub/desiutil/pull/152
 
 3.0.3 (2020-08-04)
 ------------------

--- a/py/desiutil/test/test_timer.py
+++ b/py/desiutil/test/test_timer.py
@@ -126,10 +126,10 @@ class TestTimer(unittest.TestCase):
     @unittest.skipUnless(dateutil_installed, "dateutil not installed")
     def test_parsetime_dateutil(self):
         """If dateutil installed, test fancy date string parsing"""
-        t0 = parsetime("Tue Sep 22 13:42:26 PDT 2020")
+        # t0 = parsetime("Tue Sep 22 13:42:26 PDT 2020")
+        # self.assertAlmostEqual(t0, 1600807346.0)
         t1 = parsetime("2020-09-22T13:42:26-07:00")
-        self.assertAlmostEqual(t0, t1)
-        self.assertAlmostEqual(t0, 1600807346.0)
+        self.assertAlmostEqual(t1, 1600807346.0)
 
         with self.assertRaises(ValueError):
             t2 = parsetime("My Birthday")
@@ -137,8 +137,8 @@ class TestTimer(unittest.TestCase):
     @unittest.skipIf(dateutil_installed, "dateutil installed")
     def test_parsetime_no_dateutil(self):
         """If dateutil not installed, confirm failure modes"""
-        with unittest.assertRaises(ValueError):
-            t0 = parsetime("Tue Sep 22 13:42:26 PDT 2020")
+        # with unittest.assertRaises(ValueError):
+        #     t0 = parsetime("Tue Sep 22 13:42:26 PDT 2020")
         with unittest.assertRaises(ValueError):
             t1 = parsetime("2020-09-22T13:42:26-07:00")
 

--- a/py/desiutil/test/test_timer.py
+++ b/py/desiutil/test/test_timer.py
@@ -125,7 +125,12 @@ class TestTimer(unittest.TestCase):
 
     @unittest.skipUnless(dateutil_installed, "dateutil not installed")
     def test_parsetime_dateutil(self):
-        """If dateutil installed, test fancy date string parsing"""
+        """If dateutil installed, test ISO-8601 date string parsing
+
+        Fancier "Tue Sep 22 13:42:26 PDT 2020" parsing may or may not
+        work depending upon timezone knowledge of host machine; not
+        tested or supported for now, but may be re-added later if needed.
+        """
         # t0 = parsetime("Tue Sep 22 13:42:26 PDT 2020")
         # self.assertAlmostEqual(t0, 1600807346.0)
         t1 = parsetime("2020-09-22T13:42:26-07:00")

--- a/py/desiutil/test/test_timer.py
+++ b/py/desiutil/test/test_timer.py
@@ -112,24 +112,24 @@ class TestTimer(unittest.TestCase):
         t1 = parsetime(1600807346.0)
         t2 = parsetime("1600807346")
         t3 = parsetime("1600807346.0")
-        self.assertEqual(t0, 1600807346.0)
-        self.assertEqual(t0, t1)
-        self.assertEqual(t0, t2)
-        self.assertEqual(t0, t3)
+        self.assertAlmostEqual(t0, 1600807346.0)
+        self.assertAlmostEqual(t0, t1)
+        self.assertAlmostEqual(t0, t2)
+        self.assertAlmostEqual(t0, t3)
 
         timer = Timer()
         timer.start('blat', starttime=1600807346)
         timer.stop('blat', stoptime=1600807346+2)
-        self.assertEqual(timer.timers['blat']['start'], 1600807346.0)
-        self.assertEqual(timer.timers['blat']['duration'], 2)
+        self.assertAlmostEqual(timer.timers['blat']['start'], 1600807346.0)
+        self.assertAlmostEqual(timer.timers['blat']['duration'], 2)
 
     @unittest.skipUnless(dateutil_installed, "dateutil not installed")
     def test_parsetime_dateutil(self):
         """If dateutil installed, test fancy date string parsing"""
         t0 = parsetime("Tue Sep 22 13:42:26 PDT 2020")
         t1 = parsetime("2020-09-22T13:42:26-07:00")
-        self.assertEqual(t0, t1)
-        self.assertEqual(t0, 1600807346.0)
+        self.assertAlmostEqual(t0, t1)
+        self.assertAlmostEqual(t0, 1600807346.0)
 
         with self.assertRaises(ValueError):
             t2 = parsetime("My Birthday")

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -61,9 +61,11 @@ class Timer(object):
     TIMER:<START|STOP>:<filename>:<lineno>:<funcname>: <message>
     """
     
-    def __init__(self):
+    def __init__(self, silent=False):
         """
         Create a Timer object.
+
+        if `silent` is True, record timing but don't print log messages.
 
         Timing info is kept in `self.timers` dict
 
@@ -72,6 +74,7 @@ class Timer(object):
         timers[name]['duration'] = stop - start (seconds)
         """
         self.timers = dict()
+        self.silent = silent
     
     def _prefix(self, step):
         """
@@ -92,29 +95,85 @@ class Timer(object):
         
         filename = os.path.basename(caller.filename)
         return f"TIMER-{step}:{filename}:{caller.lineno}:{caller.name}:"
+
+    def print(self, level, message):
+        """Print message with timing level prefix if not `self.silent`
+
+        Args:
+           level (str): timing level ('START', 'STOP', 'WARNING', ...)
+           message (str): message to print after standardized prefix
+        """
+        if not self.silent:
+            print(self._prefix(level), message)
+
+    def _parsetime(self, t):
+        """Parse time as int,float,str(int),str(float),ISO-8601, or Unix `date`
+
+        If `t` is None, return `time.time()`
+
+        Returns `t` as float Unix seconds since epoch timestamp
+        """
+        if t is None:
+            return time.time()
+        elif isinstance(t, (float, int)):
+            return float(t)
+        elif isinstance(t, str):
+            try:
+                #- int or float passed in as string
+                t = float(t)
+            except ValueError:
+                #- see if dateutil is installed to parse
+                #- ISO-8601 string, or output of Unix `date` without options
+                try:
+                    import dateutil.parser
+                except ImportError:
+                    raise ValueError(f"Can't parse start time {t}; " \
+                                      "install dateutil or use int/float " \
+                                      "(e.g. from Unix `date +%s`")
+
+                try:
+                    t = dateutil.parser.parse(t).timestamp()
+                except:
+                    raise ValueError(f"Can't parse start time {t}; " \
+                                      "use int/float or ISO-8601 or " \
+                                      "Unix `date` output")
+
+        return t
     
-    def start(self, name):
+    def start(self, name, starttime=None):
         """Start a timer `name` (str); prints TIMER-START message
 
         Args:
             name (str): name of timer to stop
 
+        Options:
+            starttime (str or float): start time to use instead of now
+
         If `name` is started multiple times, the last call to `.start` is used
         for the timestamp.
+
+        Tries to parse `starttime` in this order:
+
+            1. (float) Unix time-since epoch
+            2. (str) ISO-8601
+            3. (str) Unix `date` cmd, e.g. "Mon Sep 21 20:09:48 PDT 2020"
         """
-        t0 = time.time()
-        isotime = datetime.datetime.fromtimestamp(t0).isoformat()
+        starttime = self._parsetime(starttime)
+        isotime = datetime.datetime.fromtimestamp(starttime).isoformat()
         if name in self.timers:
-            print(self._prefix('WARNING'), f'Restarting {name} at {isotime}')
+            self.print('WARNING', f'Restarting {name} at {isotime}')
         
-        print(self._prefix('START'), f'Starting {name} at {isotime}')
-        self.timers[name] = dict(start=t0)
+        self.print('START', f'Starting {name} at {isotime}')
+        self.timers[name] = dict(start=starttime)
     
-    def stop(self, name):
+    def stop(self, name, stoptime=None):
         """Stop timer `name` (str); prints TIMER-STOP message
 
         Args:
             name (str): name of timer to stop
+
+        Options:
+            stoptime (str or float): stop time to use instead of now
 
         Returns time since start in seconds, or -1.0 if `name` wasn't started
 
@@ -124,23 +183,29 @@ class Timer(object):
 
         If a timer is stopped multiple times, the final stop and duration
         are timestamped as the last call to `Timer.stop`.
+
+        Tries to parse `stoptime` in this order:
+
+            1. (float) Unix time-since epoch
+            2. (str) ISO-8601
+            3. (str) Unix `date` cmd, e.g. "Mon Sep 21 20:09:48 PDT 2020"
         """
         #- non-fatal ERROR: trying to stop a timer that wasn't started
-        t1 = time.time()
-        isotime = datetime.datetime.fromtimestamp(t1).isoformat()
+        stoptime = self._parsetime(stoptime)
+        isotime = datetime.datetime.fromtimestamp(stoptime).isoformat()
         if name not in self.timers:
-            print(self._prefix('ERROR'), f'Tried to stop non-existent timer {name} at {isotime}')
+            self.print('ERROR', f'Tried to stop non-existent timer {name} at {isotime}')
             return -1.0
 
         #- WARNING: resetting the stop time of a timer that was already stopped
         if 'stop' in self.timers[name]:
-            print(self._prefix('WARNING'), f'Resetting stop time of {name} at {isotime}')
+            self.print('WARNING', f'Resetting stop time of {name} at {isotime}')
         
         #- All clear; proceed
-        self.timers[name]['stop'] = t1
+        self.timers[name]['stop'] = stoptime
         dt = self.timers[name]['stop'] - self.timers[name]['start']
         self.timers[name]['duration'] = dt
-        print(self._prefix('STOP'), f'Stopping {name} at {isotime}; duration {dt:.2f} seconds')
+        self.print('STOP', f'Stopping {name} at {isotime}; duration {dt:.2f} seconds')
         return dt
 
     def stopall(self):
@@ -182,7 +247,7 @@ class Timer(object):
         for name in t:
             for key in ['start', 'stop']:
                 if key in t[name]:
-                    isotime = datetime.datetime.fromtimestamp(t[name][key]).isoformat()
+                    isotime = timestamp2isotime(t[name][key])
                     t[name][key] = isotime
 
         return t
@@ -205,4 +270,73 @@ class Timer(object):
         #- Convert to human-friendly formatted json string
         return json.dumps(t, indent=2)
         
+
+#-----
+#- Utility functions
+
+def timestamp2isotime(timestamp):
+    """Return seconds since epoch `timestamp` as ISO-8601 string
+    """
+    return datetime.datetime.fromtimestamp(timestamp).isoformat()
+
+def compute_stats(timerlist):
+    """Compute timer min/max/mean/median stats
+
+    Args:
+        timerlist: list of Timer objects
+
+    Returns: dict[timername][...] with keys
+    for start/stop/duration.min/max/mean/median
+
+    Different Timers can have different named subtimers
+    """
+
+    #- Minimize timer import time by loading numpy only if needed
+    import numpy as np
+
+    #- Result dictionary to fill
+    stats = dict()
+
+    #- Extract timers dictionaries
+    timerlist = [t.timers for t in timerlist]
+
+    #- Get the name of all individual timers in the list of timers
+    #- while retaining order of first appearance
+    names = dict()
+    for t in timerlist:
+        for n in t.keys():
+            names[n] = 1
+    names = list(names.keys()) # cPy3.6 and any py3.7 preserves key order
+
+    for name in names:
+        duration = list()
+        start = list()
+        stop = list()
+        for t in timerlist:
+            if name in t:
+                if 'duration' in t[name]:
+                    duration.append(t[name]['duration'])
+                    start.append(t[name]['start'])
+                    stop.append(t[name]['stop'])
+
+        duration = np.array(duration)
+        start = np.array(start)
+        stop = np.array(stop)
+        stats[name] = {
+            'start.min': timestamp2isotime(np.min(start)),
+            'start.max': timestamp2isotime(np.max(start)),
+            'start.mean': timestamp2isotime(np.mean(start)),
+            'start.median': timestamp2isotime(np.median(start)),
+            'stop.min': timestamp2isotime(np.min(stop)),
+            'stop.max': timestamp2isotime(np.max(stop)),
+            'stop.mean': timestamp2isotime(np.mean(stop)),
+            'stop.median': timestamp2isotime(np.median(stop)),
+            'duration.min': np.min(duration),
+            'duration.max': np.max(duration),
+            'duration.mean': np.mean(duration),
+            'duration.median': np.median(duration),
+            'n': len(duration),
+            }
+
+    return stats
 

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -284,9 +284,14 @@ def parsetime(t):
             try:
                 t = dateutil.parser.parse(t).timestamp()
             except:
-                raise ValueError(f"Can't parse start time {t}; " \
-                                  "use int/float or ISO-8601 or " \
-                                  "Unix `date` output")
+                try:
+                    #- Travis CI doesn't know about US timezones...
+                    tzinfos = {"PST": -8*3600, "PDT": -7*3600, "MST":-7*3600, "MDT":-6*3600}
+                    t = dateutil.parser.parse(t, tzinfos=tzinfos).timestamp()
+                except:
+                    raise ValueError(f"Can't parse start time {t}; " \
+                                      "use int/float or ISO-8601 or " \
+                                      "Unix `date` output")
 
     return t
 

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -284,14 +284,9 @@ def parsetime(t):
             try:
                 t = dateutil.parser.parse(t).timestamp()
             except:
-                try:
-                    #- Travis CI doesn't know about US timezones...
-                    tzinfos = {"PST": -8*3600, "PDT": -7*3600, "MST":-7*3600, "MDT":-6*3600}
-                    t = dateutil.parser.parse(t, tzinfos=tzinfos).timestamp()
-                except:
-                    raise ValueError(f"Can't parse start time {t}; " \
-                                      "use int/float or ISO-8601 or " \
-                                      "Unix `date` output")
+                raise ValueError(f"Can't parse start time {t}; " \
+                                  "use int/float or ISO-8601 or " \
+                                  "Unix `date +%s` output")
 
     return t
 

--- a/py/desiutil/timer.py
+++ b/py/desiutil/timer.py
@@ -186,10 +186,10 @@ class Timer(object):
         isotime = datetime.datetime.fromtimestamp(t1).isoformat()
         if name in self.timers:
             dt = t1 - self.timers[name]['start']
-            print(self._prefix('CANCEL'), f'Canceling timer {name} at {isotime} after {dt:.2f} seconds')
+            self._print('CANCEL', f'Canceling timer {name} at {isotime} after {dt:.2f} seconds')
             del self.timers[name]
         else:
-            print(self._prefix('WARNING'), f'Attempt to cancel non-existent timer {name} at {isotime}')
+            self._print('WARNING', f'Attempt to cancel non-existent timer {name} at {isotime}')
 
     @contextmanager
     def time(self, name):


### PR DESCRIPTION
This PR adds several features that I wanted when actually putting it into use in desispec:
  * silent option: record timing, but don't print log messages, e.g. to record timing for multiple MPI ranks without having every rank blasting timing log messages.
  * `calculate_stats` (like Ted's example from CMB-land suggested in the original Timer PR #151): combine multiple Timers into a report with min/max/mean/median of start/stop/duration.
  * options to `start` and `stop` to set the time to use instead of `time.time()`, useful for recording timing of events that may have occurred before the timer was created, e.g. python startup and imports.
  * `Timer.cancel` to discard a named timer that had been started.

I'll submit a companion desispec PR that uses these features, but this PR will need to be reviewed and merged before that one can be finalized.