### PR TITLE
Work on moving stdout / stderr redirection from desispec to desiutil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
     - pip install -U pip
     - if [[ "${MAIN_CMD}" == pycodestyle ]]; then pip install pycodestyle; fi
     - if [[ "${MAIN_CMD}" == sphinx-build* ]]; then pip install Sphinx; fi
-    - if [[ "${MAIN_CMD}" == pytest ]]; then pip install -r requirements.txt; fi
+    - if [[ "${MAIN_CMD}" == pytest ]]; then pip install -r requirements.txt; pip install . ; fi
     - if [[ "${SETUP_CMD}" == '--cov' ]]; then pip install pytest-cov coveralls; fi
     # - if [[ "${MAIN_CMD}" == python* || "${MAIN_CMD}" == coverage* ]]; then pip install -r requirements.txt; fi
     - if [[ -n "${ASTROPY_VERSION}" ]]; then pip install -U "astropy${ASTROPY_VERSION}"; fi

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -44,6 +44,9 @@ desiutil API
 .. automodule:: desiutil.plots
     :members:
 
+.. automodule:: desiutil.redirect
+    :members:
+
 .. automodule:: desiutil.setup
     :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,15 +5,17 @@ Change Log
 3.0.4 (unreleased)
 ------------------
 
-* Add `Timer` class to standardize timing reports (PRs `#151`_, `#152`_).
+* Add :class:`~desiutil.timer.Timer` class to standardize timing reports (PRs `#151`_, `#152`_).
+* Add :mod:`~desiutil.redirect` for utilites related to redirecting STDOUT (PR `#153`_).
 
 .. _`#151`: https://github.com/desihub/desiutil/pull/151
 .. _`#152`: https://github.com/desihub/desiutil/pull/152
+.. _`#153`: https://github.com/desihub/desiutil/pull/153
 
 3.0.3 (2020-08-04)
 ------------------
 
-* Improve installation robustness when parsing DESICONDA envvar;
+* Improve installation robustness when parsing :envvar:`DESICONDA` environment variable;
   fix py3.8 SyntaxWarnings about "is not" usage (PR `#150`_).
 
 .. _`#150`: https://github.com/desihub/desiutil/pull/150

--- a/py/desiutil/redirect.py
+++ b/py/desiutil/redirect.py
@@ -40,12 +40,12 @@ def get_libc():
             # Linux systems
             _c_stdout = ctypes.c_void_p.in_dll(_libc, 'stdout')
             _c_stderr = ctypes.c_void_p.in_dll(_libc, 'stderr')
-        except:
+        except ValueError:
             try:
                 # Darwin
                 _c_stdout = ctypes.c_void_p.in_dll(_libc, '__stdoutp')
                 _c_stderr = ctypes.c_void_p.in_dll(_libc, '__stdoutp')
-            except:
+            except ValueError:
                 # Neither!
                 pass
     return (_libc, _c_stdout, _c_stderr)

--- a/py/desiutil/redirect.py
+++ b/py/desiutil/redirect.py
@@ -212,8 +212,6 @@ def stdouterr_redirected(to=None, comm=None):
 
     _close_redirect(file)
 
-    print("redirect DONE", flush=True)
-
     if comm is not None:
         # Concatenate per-process files if we have multiple processes.
         comm.barrier()

--- a/py/desiutil/redirect.py
+++ b/py/desiutil/redirect.py
@@ -173,7 +173,7 @@ def stdouterr_redirected(to=None, comm=None):
     except:
         log = get_logger()
         log.error(
-            "Failed to open redirection file {} at {}".format(pto, time.asctime())
+            "Failed to open redirection file %s at %s", pto, time.asctime())
         )
         fail_open = 1
 
@@ -185,7 +185,7 @@ def stdouterr_redirected(to=None, comm=None):
         if rank == 0:
             log = get_logger()
             log.error(
-                "Failed to start redirect to {} at {}".format(to, time.asctime())
+                "Failed to start redirect to %s at %s", to, time.asctime())
             )
 
         _close_redirect(file)
@@ -229,7 +229,7 @@ def stdouterr_redirected(to=None, comm=None):
 
     if rank == 0:
         log = get_logger()
-        log.info("End log redirection to {} at {}".format(to, time.asctime()))
+        log.info("End log redirection to %s at %s", to, time.asctime()))
 
     # flush python handles for good measure
     sys.stdout.flush()

--- a/py/desiutil/redirect.py
+++ b/py/desiutil/redirect.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 """
-===================
+=================
 desiutil.redirect
-===================
+=================
 
 Utilities for redirecting stdout / stderr to files.
 

--- a/py/desiutil/redirect.py
+++ b/py/desiutil/redirect.py
@@ -73,7 +73,7 @@ def stdouterr_redirected(to=None, comm=None):
         comm (mpi4py.MPI.Comm): The optional MPI communicator.
 
     """
-    libc, c_stdout, c_stderr = get_libc()
+    libc, c_stdout, c_stderr = _get_libc()
 
     nproc = 1
     rank = 0
@@ -166,7 +166,7 @@ def stdouterr_redirected(to=None, comm=None):
         to = "/dev/null"
 
     if rank == 0:
-        log = get_logger()
+        log = get_logger(timestamp=True)
         log.info("Begin log redirection to %s", to)
 
     # Try to open the redirected file.
@@ -233,7 +233,7 @@ def stdouterr_redirected(to=None, comm=None):
         comm.barrier()
 
     if rank == 0:
-        log = get_logger()
+        log = get_logger(timestamp=True)
         log.info("End log redirection to %s", to)
 
     # flush python handles for good measure

--- a/py/desiutil/redirect.py
+++ b/py/desiutil/redirect.py
@@ -1,0 +1,249 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+===================
+desiutil.redirect
+===================
+
+Utilities for redirecting stdout / stderr to files.
+
+"""
+
+import os
+import sys
+import time
+import io
+import traceback
+import logging
+import ctypes
+
+from contextlib import contextmanager
+
+from .log import get_logger, _desiutil_log_root
+
+
+# C file descriptors for stderr and stdout, used in redirection
+# context manager.
+
+libc = ctypes.CDLL(None)
+c_stdout = None
+c_stderr = None
+try:
+    # Linux systems
+    c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
+    c_stderr = ctypes.c_void_p.in_dll(libc, 'stderr')
+except:
+    try:
+        # Darwin
+        c_stdout = ctypes.c_void_p.in_dll(libc, '__stdoutp')
+        c_stderr = ctypes.c_void_p.in_dll(libc, '__stdoutp')
+    except:
+        # Neither!
+        pass
+
+@contextmanager
+def stdouterr_redirected(to=None, comm=None):
+    """Redirect stdout and stderr to a file.
+
+    The general technique is based on:
+
+    http://stackoverflow.com/questions/5081657
+    http://eli.thegreenplace.net/2015/redirecting-all-kinds-of-stdout-in-python/
+
+    If the optional communicator is specified, then each process redirects to
+    a different temporary file.  Upon exit from the context the rank zero
+    process concatenates these in order to the final file result.
+
+    If the enclosing code raises an exception, the traceback is printed to the
+    log file.
+
+    Args:
+        to (str): The output file name.
+        comm (mpi4py.MPI.Comm): The optional MPI communicator.
+
+    """
+    nproc = 1
+    rank = 0
+    MPI = None
+    if comm is not None:
+        # If we are already using MPI (comm is set), then we can safely
+        # import mpi4py.
+        from mpi4py import MPI
+        nproc = comm.size
+        rank = comm.rank
+
+    # The currently active POSIX file descriptors
+    fd_out = sys.stdout.fileno()
+    fd_err = sys.stderr.fileno()
+
+    # Save the original file descriptors so we can restore them later
+    saved_fd_out = os.dup(fd_out)
+    saved_fd_err = os.dup(fd_err)
+
+    # The DESI loggers.
+    desi_loggers = _desiutil_log_root
+
+    def _redirect(out_to, err_to):
+        # Flush the C-level buffers
+        if c_stdout is not None:
+            libc.fflush(c_stdout)
+        if c_stderr is not None:
+            libc.fflush(c_stderr)
+
+        # This closes the python file handles, and marks the POSIX
+        # file descriptors for garbage collection- UNLESS those
+        # are the special file descriptors for stderr/stdout.
+        sys.stdout.close()
+        sys.stderr.close()
+
+        # Close fd_out/fd_err if they are open, and copy the
+        # input file descriptors to these.
+        os.dup2(out_to, fd_out)
+        os.dup2(err_to, fd_err)
+
+        # Create a new sys.stdout / sys.stderr that points to the
+        # redirected POSIX file descriptors.  In Python 3, these
+        # are actually higher level IO objects.
+        if sys.version_info[0] < 3:
+            sys.stdout = os.fdopen(fd_out, "wb")
+            sys.stderr = os.fdopen(fd_err, "wb")
+        else:
+            # Python 3 case
+            sys.stdout = io.TextIOWrapper(os.fdopen(fd_out, 'wb'))
+            sys.stderr = io.TextIOWrapper(os.fdopen(fd_err, 'wb'))
+
+        # update DESI logging to use new stdout
+        for name, logger in desi_loggers.items():
+            hformat = None
+            while len(logger.handlers) > 0:
+                h = logger.handlers[0]
+                if hformat is None:
+                    hformat = h.formatter._fmt
+                logger.removeHandler(h)
+            # Add the current stdout.
+            ch = logging.StreamHandler(sys.stdout)
+            formatter = logging.Formatter(hformat, datefmt='%Y-%m-%dT%H:%M:%S')
+            ch.setFormatter(formatter)
+            logger.addHandler(ch)
+
+    def _open_redirect(filename):
+        # Open python file, which creates low-level POSIX file
+        # descriptor.
+        file_handle = open(filename, "w")
+
+        # Redirect stdout/stderr to this new file descriptor.
+        _redirect(out_to=file_handle.fileno(), err_to=file_handle.fileno())
+        return file_handle
+
+    def _close_redirect(handle):
+        # Close python file handle, which will mark POSIX file descriptor for
+        # garbage collection.  That is fine since we are about to overwrite those.
+        if handle is not None:
+            handle.close()
+
+        # Flush python handles for good measure
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        try:
+            # Restore old stdout and stderr
+            _redirect(out_to=saved_fd_out, err_to=saved_fd_err)
+        except:
+            pass
+
+    # Redirect both stdout and stderr to the same file
+
+    if to is None:
+        to = "/dev/null"
+
+    if rank == 0:
+        log = get_logger()
+        log.info("Begin log redirection to {} at {}".format(to, time.asctime()))
+
+    # Try to open the redirected file.
+
+    pto = to
+    if to != "/dev/null" and comm is not None:
+        pto = "{}_{}".format(to, rank)
+
+    fail_open = 0
+    file = None
+    try:
+        file = _open_redirect(pto)
+    except:
+        log = get_logger()
+        log.error(
+            "Failed to open redirection file {} at {}".format(pto, time.asctime())
+        )
+        fail_open = 1
+
+    if comm is not None:
+        fail_open = comm.allreduce(fail_open, op=MPI.SUM)
+
+    if fail_open > 0:
+        # Something went wrong on one or more processes, try to recover and exit
+        if rank == 0:
+            log = get_logger()
+            log.error(
+                "Failed to start redirect to {} at {}".format(to, time.asctime())
+            )
+
+        _close_redirect(file)
+
+        # All processes raise an exception for the calling code to handle
+        msg = "Failed to start output redirect to {}".format(to)
+        raise RuntimeError(msg)
+
+    # Output should now be redirected.  Run the code.
+
+    fail_run = 0
+    try:
+        yield # Allow code to be run with the redirected output
+    except:
+        # We have an unhandled exception.  Print a stack trace to the log.
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+        print("".join(lines), flush=True)
+        fail_run = 1
+
+    # Check if any processes failed to run their code
+    if comm is not None:
+        fail_run = comm.allreduce(fail_run, op=MPI.SUM)
+
+    _close_redirect(file)
+
+    print("redirect DONE", flush=True)
+
+    if comm is not None:
+        # Concatenate per-process files if we have multiple processes.
+        comm.barrier()
+        if rank == 0:
+            with open(to, "w") as outfile:
+                for p in range(nproc):
+                    outfile.write(
+                        "================= Process {} =================\n".format(p)
+                    )
+                    fname = "{}_{}".format(to, p)
+                    with open(fname) as infile:
+                        outfile.write(infile.read())
+                    os.remove(fname)
+        comm.barrier()
+
+    if rank == 0:
+        log = get_logger()
+        log.info("End log redirection to {} at {}".format(to, time.asctime()))
+
+    # flush python handles for good measure
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    if fail_run > 0:
+        msg = "{} processes raised an exception while logs were redirected".format(
+            fail_run
+        )
+        if rank == 0:
+            log = get_logger()
+            log.error(msg)
+        raise RuntimeError(msg)
+
+    return

--- a/py/desiutil/test/test_redirect.py
+++ b/py/desiutil/test/test_redirect.py
@@ -8,20 +8,75 @@ tests on machines where MPI is available, but skip them when running on
 CI environments, etc.
 
 """
+import sys
 import os
 import re
 import unittest
 import tempfile
 
-from ..redirect import stdouterr_redirected
+import subprocess as sp
+
+
+test_serial_source = """
+import sys
+import os
+
+from desiutil.redirect import stdouterr_redirected
+
+def generate_output(error=False):
+    if error:
+        raise RuntimeError("Error!")
+    else:
+        for i in range(5):
+            print("{}".format(i))
+
+filename = sys.argv[1]
+with_error = (sys.argv[2] == "1")
+
+with stdouterr_redirected(to=filename):
+    if with_error:
+        generate_output(error=True)
+    else:
+        generate_output()
+
+"""
+
+test_mpi_source = """
+from mpi4py import MPI
+import sys
+import os
+
+from desiutil.redirect import stdouterr_redirected
+
+def generate_output(error=False):
+    if error:
+        raise RuntimeError("Error!")
+    else:
+        for i in range(5):
+            print("{}".format(i))
+
+filename = sys.argv[1]
+with_error = (sys.argv[2] == "1")
+
+with stdouterr_redirected(to=filename, comm=MPI.COMM_WORLD):
+    if with_error and MPI.COMM_WORLD.rank == MPI.COMM_WORLD.size - 1:
+        generate_output(error=True)
+    else:
+        generate_output()
+
+"""
 
 
 class TestRedirect(unittest.TestCase):
-    """Test desiutil.redirect
-    """
+    """Test desiutil.redirect"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_dir = tempfile.mkdtemp()
 
     def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
+        self.test_serial_script = os.path.join(self.test_dir, "run_serial.py")
+        self.test_mpi_script = os.path.join(self.test_dir, "run_mpi.py")
         self.n_lines = 5
         self.have_mpi = False
         self.comm = None
@@ -30,22 +85,21 @@ class TestRedirect(unittest.TestCase):
         if "RUN_MPI_TESTS" in os.environ:
             try:
                 from mpi4py import MPI
+
                 self.have_mpi = True
                 self.comm = MPI.COMM_WORLD
                 self.rank = self.comm.rank
                 self.nproc = self.comm.size
             except:
                 pass
+        if self.rank == 0:
+            with open(self.test_serial_script, "w") as f:
+                f.write(test_serial_source)
+            with open(self.test_mpi_script, "w") as f:
+                f.write(test_mpi_source)
 
     def tearDown(self):
         pass
-
-    def generate_output(self, error=False):
-        if error:
-            raise RuntimeError("Error!")
-        else:
-            for i in range(self.n_lines):
-                print("{}".format(i))
 
     def check_serial(self, file):
         with open(file, "r") as f:
@@ -53,45 +107,25 @@ class TestRedirect(unittest.TestCase):
                 check_num = int(line_str.split()[0])
                 self.assertTrue(line_num == check_num)
 
-    def check_mpi(self, file):
-        pstr_pat = re.compile("=+ Process (\d+) =+.*")
-        fail = False
-        if self.rank == 0:
-            try:
-                with open(file, "r") as f:
-                    cur_p = -1
-                    p_off = 0
-                    for line in f:
-                        mat = pstr_pat.match(line)
-                        if mat is not None:
-                            # Starting a new process section, verify they are in
-                            # rank order.
-                            new_p = int(mat.group(1))
-                            self.assertTrue(new_p == cur_p + 1)
-                            p_off = 0
-                            cur_p = new_p
-                        else:
-                            check_num = int(line.split()[0])
-                            self.assertTrue(p_off == check_num)
-                            p_off += 1
-            except:
-                fail = True
-        fail = self.comm.bcast(fail, root=0)
-        if fail:
-            raise RuntimeError("MPI redirect output not correct")
-        self.comm.barrier()
-
     def test_serial(self):
         outfile = os.path.join(self.test_dir, "redirect_serial.log")
-        with stdouterr_redirected(to=outfile):
-            self.generate_output()
+        com = ["python", self.test_serial_script, outfile, "0"]
+        out = sp.run(
+            com, check=True, universal_newlines=True, stdout=sp.PIPE, stderr=sp.STDOUT
+        ).stdout
         self.check_serial(outfile)
 
     def test_serial_error(self):
         outfile = os.path.join(self.test_dir, "redirect_serial_error.log")
+        com = ["python", self.test_serial_script, outfile, "1"]
         try:
-            with stdouterr_redirected(to=outfile):
-                self.generate_output(error=True)
+            out = sp.run(
+                com,
+                check=True,
+                universal_newlines=True,
+                stdout=sp.PIPE,
+                stderr=sp.STDOUT,
+            ).stdout
         except:
             print("Successfully handled exception")
         else:
@@ -101,33 +135,14 @@ class TestRedirect(unittest.TestCase):
         if not self.have_mpi:
             return
         outfile = os.path.join(self.test_dir, "redirect_mpi.log")
-        with stdouterr_redirected(to=outfile, comm=self.comm):
-            self.generate_output()
-        self.check_mpi(outfile)
-
-    def test_mpi_error(self):
-        if not self.have_mpi:
-            return
-        outfile = os.path.join(self.test_dir, "redirect_mpi_error.log")
-        try:
-            with stdouterr_redirected(to=outfile, comm=self.comm):
-                if self.rank == self.nproc - 1:
-                    self.generate_output(error=True)
-                else:
-                    self.generate_output()
-        except:
-            print("Successfully handled exception")
-            if self.rank == 0:
-                with open(outfile, "r") as f:
-                    for line in f:
-                        print(line, flush=True)
-        else:
-            raise RuntimeError("Did not successfully handle exception")
+        print("\nTo manually test MPI redirection, run:")
+        print("  mpirun -np 2 python {} {} 0".format(self.test_mpi_script, outfile))
+        print("And then inspect the {} output file\n".format(outfile))
 
 
 def test_suite():
     """Allows testing of only this module with the command::
 
-        python setup.py test -m <modulename>
+    python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desiutil/test/test_redirect.py
+++ b/py/desiutil/test/test_redirect.py
@@ -17,6 +17,9 @@ import shutil
 
 import subprocess as sp
 
+# This test requires desiutil to be installed for spawned scripts;
+# skip if we are doing a test prior to a full installation.
+not_installed = bool(sp.call(['python', '-c', 'import desiutil.redirect']))
 
 test_serial_source = """
 import sys
@@ -112,6 +115,7 @@ class TestRedirect(unittest.TestCase):
                 check_num = int(line_str.split()[0])
                 self.assertTrue(line_num == check_num)
 
+    @unittest.skipIf(not_installed, "stdout redirection tests require desiutil to be installed first")
     def test_serial(self):
         outfile = os.path.join(self.test_dir, "redirect_serial.log")
         com = ["python", self.test_serial_script, outfile, "0"]
@@ -120,6 +124,7 @@ class TestRedirect(unittest.TestCase):
         ).stdout
         self.check_serial(outfile)
 
+    @unittest.skipIf(not_installed, "stdout redirection tests require desiutil to be installed first")
     def test_serial_error(self):
         outfile = os.path.join(self.test_dir, "redirect_serial_error.log")
         com = ["python", self.test_serial_script, outfile, "1"]

--- a/py/desiutil/test/test_redirect.py
+++ b/py/desiutil/test/test_redirect.py
@@ -1,0 +1,133 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.redirect.
+
+Note that desiutil is not MPI-aware, so we only run MPI unit tests if the
+'RUN_MPI_TESTS' environment variable is set.  This way we can run those
+tests on machines where MPI is available, but skip them when running on
+CI environments, etc.
+
+"""
+import os
+import re
+import unittest
+import tempfile
+
+from ..redirect import stdouterr_redirected
+
+
+class TestRedirect(unittest.TestCase):
+    """Test desiutil.redirect
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.n_lines = 5
+        self.have_mpi = False
+        self.comm = None
+        self.rank = 0
+        self.nproc = 1
+        if "RUN_MPI_TESTS" in os.environ:
+            try:
+                from mpi4py import MPI
+                self.have_mpi = True
+                self.comm = MPI.COMM_WORLD
+                self.rank = self.comm.rank
+                self.nproc = self.comm.size
+            except:
+                pass
+
+    def tearDown(self):
+        pass
+
+    def generate_output(self, error=False):
+        if error:
+            raise RuntimeError("Error!")
+        else:
+            for i in range(self.n_lines):
+                print("{}".format(i))
+
+    def check_serial(self, file):
+        with open(file, "r") as f:
+            for line_num, line_str in enumerate(f):
+                check_num = int(line_str.split()[0])
+                self.assertTrue(line_num == check_num)
+
+    def check_mpi(self, file):
+        pstr_pat = re.compile("=+ Process (\d+) =+.*")
+        fail = False
+        if self.rank == 0:
+            try:
+                with open(file, "r") as f:
+                    cur_p = -1
+                    p_off = 0
+                    for line in f:
+                        mat = pstr_pat.match(line)
+                        if mat is not None:
+                            # Starting a new process section, verify they are in
+                            # rank order.
+                            new_p = int(mat.group(1))
+                            self.assertTrue(new_p == cur_p + 1)
+                            p_off = 0
+                            cur_p = new_p
+                        else:
+                            check_num = int(line.split()[0])
+                            self.assertTrue(p_off == check_num)
+                            p_off += 1
+            except:
+                fail = True
+        fail = self.comm.bcast(fail, root=0)
+        if fail:
+            raise RuntimeError("MPI redirect output not correct")
+        self.comm.barrier()
+
+    def test_serial(self):
+        outfile = os.path.join(self.test_dir, "redirect_serial.log")
+        with stdouterr_redirected(to=outfile):
+            self.generate_output()
+        self.check_serial(outfile)
+
+    def test_serial_error(self):
+        outfile = os.path.join(self.test_dir, "redirect_serial_error.log")
+        try:
+            with stdouterr_redirected(to=outfile):
+                self.generate_output(error=True)
+        except:
+            print("Successfully handled exception")
+        else:
+            raise RuntimeError("Did not successfully handle exception")
+
+    def test_mpi(self):
+        if not self.have_mpi:
+            return
+        outfile = os.path.join(self.test_dir, "redirect_mpi.log")
+        with stdouterr_redirected(to=outfile, comm=self.comm):
+            self.generate_output()
+        self.check_mpi(outfile)
+
+    def test_mpi_error(self):
+        if not self.have_mpi:
+            return
+        outfile = os.path.join(self.test_dir, "redirect_mpi_error.log")
+        try:
+            with stdouterr_redirected(to=outfile, comm=self.comm):
+                if self.rank == self.nproc - 1:
+                    self.generate_output(error=True)
+                else:
+                    self.generate_output()
+        except:
+            print("Successfully handled exception")
+            if self.rank == 0:
+                with open(outfile, "r") as f:
+                    for line in f:
+                        print(line, flush=True)
+        else:
+            raise RuntimeError("Did not successfully handle exception")
+
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desiutil/test/test_redirect.py
+++ b/py/desiutil/test/test_redirect.py
@@ -13,6 +13,7 @@ import os
 import re
 import unittest
 import tempfile
+import shutil
 
 import subprocess as sp
 
@@ -73,6 +74,10 @@ class TestRedirect(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.test_dir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.test_dir)
 
     def setUp(self):
         self.test_serial_script = os.path.join(self.test_dir, "run_serial.py")


### PR DESCRIPTION
The unit tests are not yet working, since redirecting stdout actually breaks the unit test runner (which has a persistent handle to sys.stdout).  I am working on a unit test that runs the redirection in a subprocess.