### PR TITLE
Support recent astropy versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
         name: Unit tests
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.6, 3.7, 3.8]
@@ -43,7 +43,7 @@ jobs:
         name: Test coverage
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.6, 3.7, 3.8]
-                # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
+                astropy-version: ['==4.0.1.post1', '<4.1', '<5.0']
 
         steps:
             - name: Checkout code
@@ -34,7 +34,7 @@ jobs:
                 python -m pip install --upgrade pip wheel
                 python -m pip install pytest
                 if [ -f requirements.txt ]; then pip install -r requirements.txt; pip install .; fi
-#                pip install -U "astropy${{ matrix.astropy-version }}"
+                pip install -U "astropy${{ matrix.astropy-version }}"
 #                if [ "${{ matrix.astropy-version }}" = "<3.0" ]; then pip install -U "healpy==1.12.9"; fi
             - name: Run the test
               run: pytest
@@ -47,6 +47,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]
+                astropy-version: ['<4.1']
 
         steps:
             - name: Checkout code
@@ -62,6 +63,7 @@ jobs:
                 python -m pip install --upgrade pip wheel
                 python -m pip install pytest pytest-cov coveralls
                 if [ -f requirements.txt ]; then pip install -r requirements.txt; pip install .; fi
+                pip install -U "astropy${{ matrix.astropy-version }}"
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,9 +20,6 @@ jobs:
                 python-version: [3.6, 3.7, 3.8]
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0']
 
-        env:
-            SETUPTOOLS_USE_DISTUTILS: stdlib
-
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
         name: Unit tests
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: false
+            fail-fast: true
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,6 +20,9 @@ jobs:
                 python-version: [3.6, 3.7, 3.8]
                 astropy-version: ['==4.0.1.post1', '<4.1', '<5.0']
 
+        env:
+            SETUPTOOLS_USE_DISTUTILS: stdlib
+
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ Change Log
 3.1.1 (unreleased)
 ------------------
 
+* ``astropy.erfa`` no longer exists in more recent versions of Astropy (PR `#159`_).
 * Add function :func:`dust.extinction_total_to_selective_ratio` (PR `#157`_).
 
 .. _`#157`: https://github.com/desihub/desiutil/pull/157
+.. _`#159`: https://github.com/desihub/desiutil/pull/159
 
 3.1.0 (2020-12-11)
 ------------------

--- a/py/desiutil/iers.py
+++ b/py/desiutil/iers.py
@@ -124,8 +124,9 @@ def freeze_iers(name='iers_frozen.ecsv', ignore_warnings=True):
                                     message=r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
         except AttributeError:
             # Astropy >= 4.2
+            from erfa import ErfaWarning
             warnings.filterwarnings('ignore',
-                                    category=erfa.ErfaWarning,
+                                    category=ErfaWarning,
                                     message=r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
 
         warnings.filterwarnings('ignore',

--- a/py/desiutil/iers.py
+++ b/py/desiutil/iers.py
@@ -118,9 +118,13 @@ def freeze_iers(name='iers_frozen.ecsv', ignore_warnings=True):
         raise RuntimeError('Frozen IERS is not installed as the default ({0} v. {1}).'.format(auto_class.__class__, iers.__class__))
 
     if ignore_warnings:
-        warnings.filterwarnings('ignore',
-                                category=astropy._erfa.core.ErfaWarning,
-                                message=r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
+        try :
+            warnings.filterwarnings('ignore',
+                                    category=astropy._erfa.core.ErfaWarning,
+                                    message=r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
+        except AttributeError :
+            pass
+            
         warnings.filterwarnings('ignore',
                                 category=astropy.utils.exceptions.AstropyWarning,
                                 message=r'Tried to get polar motions for times after IERS data')

--- a/py/desiutil/iers.py
+++ b/py/desiutil/iers.py
@@ -118,13 +118,16 @@ def freeze_iers(name='iers_frozen.ecsv', ignore_warnings=True):
         raise RuntimeError('Frozen IERS is not installed as the default ({0} v. {1}).'.format(auto_class.__class__, iers.__class__))
 
     if ignore_warnings:
-        try :
+        try:
             warnings.filterwarnings('ignore',
                                     category=astropy._erfa.core.ErfaWarning,
                                     message=r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
-        except AttributeError :
-            pass
-            
+        except AttributeError:
+            # Astropy >= 4.2
+            warnings.filterwarnings('ignore',
+                                    category=erfa.ErfaWarning,
+                                    message=r'ERFA function \"[a-z0-9_]+\" yielded [0-9]+ of \"dubious year')
+
         warnings.filterwarnings('ignore',
                                 category=astropy.utils.exceptions.AstropyWarning,
                                 message=r'Tried to get polar motions for times after IERS data')

--- a/py/desiutil/svn.py
+++ b/py/desiutil/svn.py
@@ -53,7 +53,7 @@ def last_tag(tags, username=None):
     :class:`str`
         The most recent tag found in ``tags``.
     """
-    from distutils.version import StrictVersion as V
+    from packaging.version import parse as V
     from subprocess import Popen, PIPE
     command = ['svn', '--non-interactive']
     if username is not None:

--- a/py/desiutil/test/test_setup.py
+++ b/py/desiutil/test/test_setup.py
@@ -8,8 +8,10 @@ import shutil
 import unittest
 from unittest.mock import call, patch
 from tempfile import mkdtemp
-from distutils import log
+from packaging import version
+from setuptools import __version__ as setuptools_version
 from setuptools import sandbox
+from distutils import log
 from ..setup import find_version_directory, get_version, update_version
 from .. import __version__ as desiutil_version
 
@@ -26,6 +28,7 @@ class TestSetup(unittest.TestCase):
         if hasattr(sandbox, 'hide_setuptools'):
             sandbox.hide_setuptools = lambda: None
         cls.old_threshold = log.set_threshold(log.WARN)
+        cls.distutils_log = 'distutils.log.Log._log'
 
     @classmethod
     def tearDownClass(cls):
@@ -85,13 +88,13 @@ setup(name="{0.fake_name}",
             i.write(init)
         os.chdir(package_dir)
         v_file = os.path.join(package_dir, self.fake_name, '_version.py')
-        with patch('distutils.log.Log._log') as mock_log:
+        with patch(self.distutils_log) as mock_log:
             self.run_setup('setup.py', ['version'])
             self.assertTrue(os.path.exists(v_file))
             self.assertListEqual(mock_log.mock_calls,
                                  [call(2, 'running %s', ('version',)),
                                   call(2, 'Version is now 0.0.1.dev0.', ())])
-        with patch('distutils.log.Log._log') as mock_log:
+        with patch(self.distutils_log) as mock_log:
             self.run_setup('setup.py', ['version', '--tag', '1.2.3'])
             with open(v_file) as v:
                 data = v.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 requests
 pyyaml
-astropy<4.1
+astropy
 healpy
 matplotlib


### PR DESCRIPTION
[Astropy 4.2 no longer has `astropy.erfa`](https://docs.astropy.org/en/stable/whatsnew/4.2.html#whatsnew-4-2-erfa), so ERFA warnings need to support the new package.

In addition, some unexpected interaction between very recent versions of `setuptools` and `disutils` were discovered, as more recent versions of Astropy bring in these more recent versions of `setuptools`.