### PR TITLE
allow for cmake installation

### DIFF
--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -516,12 +516,16 @@ class DesiInstall(object):
             self.log.debug("Forcing build type: make")
             build_type.add('make')
         else:
+            print('cwd: ',self.working_dir);
             if os.path.exists(os.path.join(self.working_dir, 'setup.py')):
                 self.log.debug("Detected build type: py")
                 build_type.add('py')
             if os.path.exists(os.path.join(self.working_dir, 'Makefile')):
                 self.log.debug("Detected build type: make")
                 build_type.add('make')
+            elif os.path.exists(os.path.join(self.working_dir,'CMakeLists.txt')):
+                self.log.debug("Detected build type: cmake")
+                build_type.add('cmake')
             else:
                 if os.path.isdir(os.path.join(self.working_dir, 'src')):
                     self.log.debug("Detected build type: src")
@@ -834,11 +838,14 @@ class DesiInstall(object):
             # installation or we still need to compile the C/C++ product
             # (we had to construct doc/Makefile first).
             #
-            if 'make' in self.build_type or 'src' in self.build_type:
+            if ('make' in self.build_type or 'src' in self.build_type or
+                'cmake' in self.build_type):
                 if 'src' in self.build_type:
                     command = ['make', '-C', 'src', 'all']
-                else:
+                elif 'make' in self.build_type:
                     command = ['make', '-j', '8', 'install']
+                elif 'cmake' in self.build_type:
+                    command = ['cmake .; make -j 8']
                 self.log.debug(' '.join(command))
                 if self.options.test:
                     self.log.debug("Test Mode.  Skipping 'make install'.")
@@ -847,7 +854,11 @@ class DesiInstall(object):
                         os.chdir(self.install_dir)
                     else:
                         os.chdir(self.working_dir)
-                    proc = Popen(command, universal_newlines=True,
+                    if 'cmake' in self.build_type:                        
+                        proc = Popen(command, universal_newlines=True,
+                                 stdout=PIPE, stderr=PIPE, shell=True)
+                    else:
+                        proc = Popen(command, universal_newlines=True,
                                  stdout=PIPE, stderr=PIPE)
                     out, err = proc.communicate()
                     self.log.debug(out)


### PR DESCRIPTION
This modification changes desiInstall such that if there is a `CMakeLists.txt` file in the top-level directory of a package, then it will use the commands `cmake .; make -j 8` to install. This currently is for specex but should work generally and can be modified as necessary in the future. 