### PR TITLE
install py or src not both; no silent installdir fallback

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,10 @@ Change Log
 ------------------
 
 * Fixes for Numpy 1.20 (PR `#162`_).
+* :command:`desiInstall` auto derive build type "py" or "make" or "src"
+  but don't combine them (PR NNN).
+* :command:`desiInstall` only fallback to NERSC default installdir
+  if `--root` isn't specified (PR NNN).
 
 .. _`#162`: https://github.com/desihub/desiutil/pull/162
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,11 +7,12 @@ Change Log
 
 * Fixes for Numpy 1.20 (PR `#162`_).
 * :command:`desiInstall` auto derive build type "py" or "make" or "src"
-  but don't combine them (PR NNN).
+  but don't combine them (PR `#163`_).
 * :command:`desiInstall` only fallback to NERSC default installdir
-  if `--root` isn't specified (PR NNN).
+  if `--root` isn't specified (PR `#163`_).
 
 .. _`#162`: https://github.com/desihub/desiutil/pull/162
+.. _`#163`: https://github.com/desihub/desiutil/pull/163
 
 3.1.1 (2020-12-23)
 ------------------

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -207,11 +207,9 @@ Determine Build Type
 --------------------
 
 The downloaded code is scanned to determine the build type.  There are several
-possible build types that are *not* mutually exclusive.
+possible build types that are mutually exclusive.  They are derived in this
+order and the first matching method is used:
 
-plain
-    This is the default build type.  With this build type, the downloaded code
-    is simply copied to the final install directory.
 py
     If a setup.py file is detected, :command:`desiInstall` will attempt to execute
     :command:`python setup.py install`.  This build type can be suppressed with the
@@ -224,6 +222,9 @@ src
     :command:`desiInstall` will attempt to execute :command:`make -C src all`.  This build type
     *is* mutually exclusive with 'make', but is not mutually exclusive with
     the other types.
+plain
+    If no other build type is detected, the downloaded code
+    is simply copied to the final install directory.
 
 **It is the responsibility of the code developer to ensure that these
 build types do not conflict with each other.**

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -219,15 +219,13 @@ make
     :command:`make install`.
 src
     If a Makefile is not present, but a src/ directory is,
-    :command:`desiInstall` will attempt to execute :command:`make -C src all`.  This build type
-    *is* mutually exclusive with 'make', but is not mutually exclusive with
-    the other types.
+    :command:`desiInstall` will attempt to execute :command:`make -C src all`.
 plain
     If no other build type is detected, the downloaded code
     is simply copied to the final install directory.
 
-**It is the responsibility of the code developer to ensure that these
-build types do not conflict with each other.**
+**It is the responsibility of the code developer to understand these build
+types and choose the one appropriate for the package being developed.**
 
 Determine Install Directory
 ---------------------------

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -104,7 +104,7 @@ Directory Structure Assumed by the Install
 :command:`desiInstall` is primarily intended to run in a production environment that
 supports Module files, *i.e.* at NERSC.
 
-*:command:`desiInstall` does not install a Modules infrastructure for you.* You have to
+:command:`desiInstall` *does not install a Modules infrastructure for you.* You have to
 do this yourself, if your system does not already have this.
 
 For the purposes of this section, we define ``$product_root`` as the
@@ -145,7 +145,7 @@ etc/
     Miscellaneous metadata and configuration.  In most packages this only
     contains a template Module file.
 lib/pythonX.Y/site-packages/
-    Contains installed Python code.  ``X.Y`` would be ``2.7`` or ``3.5``.
+    Contains installed Python code.  ``X.Y`` would be, *e.g.*, ``3.6`` or ``3.8``.
 py/
     Sometimes we need to install a git checkout rather than an installed package.
     If so, the Python code will live in *this* directory not the ``lib/``
@@ -253,7 +253,7 @@ Module Infrastructure
 
 :command:`desiInstall` sets up the Modules infrastructure by running code in
 :mod:`desiutil.modules` that is *based on* the Python init file supplied by
-the Modules infrastructure, but updated to be both Python 2 and Python 3 compatible.
+the Modules infrastructure.
 
 Find Module File
 ----------------
@@ -319,7 +319,7 @@ If :command:`desiInstall` detects ``etc/product_data.sh``, where ``product`` sho
 replaced by the actual name of the package, it will download extra data
 not bundled with the code.  The script should download data *directly* to
 :envvar:`INSTALL_DIR`. The script should *only* be used
-with :command:`desiInstall` and Travis tests.  Note that here are other, better ways to
+with :command:`desiInstall` and unit tests.  Note that here are other, better ways to
 install and manipulate data that is bundled *with* a Python package.
 
 Fix Permissions

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -574,7 +574,7 @@ class DesiInstall(object):
             The directory selected for installation.
         """
         try:
-            self.nersc = os.envion['NERSC_HOST']
+            self.nersc = os.environ['NERSC_HOST']
         except KeyError:
             self.nersc = None
         if self.options.root is None and self.nersc is not None:

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -519,7 +519,7 @@ class DesiInstall(object):
             if os.path.exists(os.path.join(self.working_dir, 'setup.py')):
                 self.log.debug("Detected build type: py")
                 build_type.add('py')
-            if os.path.exists(os.path.join(self.working_dir, 'Makefile')):
+            elif os.path.exists(os.path.join(self.working_dir, 'Makefile')):
                 self.log.debug("Detected build type: make")
                 build_type.add('make')
             else:
@@ -573,17 +573,16 @@ class DesiInstall(object):
         :class:`str`
             The directory selected for installation.
         """
-        try:
-            self.nersc = os.environ['NERSC_HOST']
-        except KeyError:
-            self.nersc = None
-        if self.options.root is None or not os.path.isdir(self.options.root):
-            if self.nersc is not None:
-                self.options.root = self.default_nersc_dir()
-            else:
-                message = "Root install directory is missing or not set."
-                self.log.critical(message)
-                raise DesiInstallException(message)
+        self.nersc = os.getenv('NERSC_HOST') #- will be None if not set
+        if self.options.root is None and self.nersc is not None:
+            self.options.root = self.default_nersc_dir()
+
+        if (self.options.root is None or not os.path.isdir(self.options.root)) \
+                and not self.options.test:
+            message = "Root install directory is missing or not set."
+            self.log.critical(message)
+            raise DesiInstallException(message)
+
         self.install_dir = os.path.join(self.options.root, 'code',
                                         self.baseproduct, self.baseversion)
         if os.path.isdir(self.install_dir) and not self.options.test:

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -573,12 +573,15 @@ class DesiInstall(object):
         :class:`str`
             The directory selected for installation.
         """
-        self.nersc = os.getenv('NERSC_HOST') #- will be None if not set
+        try:
+            self.nersc = os.envion['NERSC_HOST']
+        except KeyError:
+            self.nersc = None
         if self.options.root is None and self.nersc is not None:
             self.options.root = self.default_nersc_dir()
 
-        if (self.options.root is None or not os.path.isdir(self.options.root)) \
-                and not self.options.test:
+        if ((self.options.root is None or not os.path.isdir(self.options.root))
+                and not self.options.test):
             message = "Root install directory is missing or not set."
             self.log.critical(message)
             raise DesiInstallException(message)

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -326,7 +326,7 @@ class TestInstall(unittest.TestCase):
         with patch.dict('os.environ', {'NERSC_HOST': 'edison', 'DESI_PRODUCT_ROOT': 'FAKE'}):
             del environ['DESI_PRODUCT_ROOT']
             test_code_version = 'test-blat-foo'
-            options = self.desiInstall.get_options(['desiutil', test_code_version])
+            options = self.desiInstall.get_options(['desiutil', test_code_version, '--test'])
             self.desiInstall.get_product_version()
             install_dir = self.desiInstall.set_install_dir()
             self.assertEqual(install_dir, join(


### PR DESCRIPTION
Our two hybrid python/C++ packages (fiberassign and specex) have now converted to using `python setup.py install` for installations, including compiling the C++ code.  This was creating a fake-failure problem for desiInstall which was noticing the `src/` directory and trying to run a non-existent Makefile.  This PR updates the installation code to use build type "py" OR "make" OR "src" but not "py" AND "src".  I left the "make" and "src" logic in place even though we don't have any packages using them now, but if the `setup.py` file is found it uses that and then moves on.

This also fixes a bug where if the `desiInstall --root ...`directory didn't exist at NERSC, the code was silently falling back to the default NERSC install location instead of warning the user that their requested installation location doesn't exist and stop.

With current master:
```
[cori12 temp] desiInstall -r $SCRATCH/desi/temp fiberassign 2.1.1
CRITICAL:install.py:866:install:2021-02-11T15:15:02: Error during compile: make: *** src: No such file or directory.  Stop.
```
That produces a useable installation, albeit without the permissions fully corrected.

With this branch there are no errors, fully successful install.
