### PR TITLE
add desiutil.depend.mergedep + tests

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,9 +10,12 @@ Change Log
   but don't combine them (PR `#163`_).
 * :command:`desiInstall` only fallback to NERSC default installdir
   if `--root` isn't specified (PR `#163`_).
+* Add :func:`desiutil.depend.mergedep` to merge DEPNAMnn/DEPVERnn
+  dependencies between different headers (PR `#164`_)
 
 .. _`#162`: https://github.com/desihub/desiutil/pull/162
 .. _`#163`: https://github.com/desihub/desiutil/pull/163
+.. _`#164`: https://github.com/desihub/desiutil/pull/164
 
 3.1.1 (2020-12-23)
 ------------------

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -174,6 +174,51 @@ def iterdep(header):
             return
     return
 
+def mergedep(srchdr, dsthdr, conflict='src'):
+    '''Merge dependencies from srchdr into dsthdr
+
+    Parameters
+    ----------
+    srchdr : dict-like
+        source dict-like object, *e.g.* :class:`astropy.io.fits.Header`,
+        with dependency keywords DEPNAMnn, DEPVERnn
+    dsthdr : dict-like
+        destination dict-like object
+    conflict : str, optional
+        'src' or 'dst' or 'exception'; see notes
+
+    Notes
+    -----
+    Dependencies in srchdr are added to dsthdr, modifying it in-place,
+    adjusting DEPNAMnn/DEPVERnn numbering as needed.  If the same dependency
+    appears in both headers with different versions, ``conflict``
+    controls the behavior:
+
+      * if 'src', the srchdr value replaces the dsthdr value
+      * if 'dst', the dsthdr value is retained unchanged
+      * if 'exception', raise a ValueError exception
+
+    Raises
+    ------
+    ValueError
+        If `conflict == 'exception'` and the same dependency name appears
+        in both headers with different values; or if `conflict` isn't one
+        of 'src', 'dst', or 'exception'.
+    '''
+    if not conflict in ('src', 'dst', 'exception'):
+        raise ValueError(f"conflict ({conflict}) should be 'src', 'dst', or 'exception'")
+
+    for name, version in iterdep(srchdr):
+        if hasdep(dsthdr, name) and getdep(dsthdr, name) != version:
+            if conflict == 'src':
+                setdep(dsthdr, name, version)
+            elif conflict == 'dst':
+                pass
+            else:
+                v2 = getdep(dsthdr, name)
+                raise ValueError(f'Version conflict for {name}: {version} != {v2}')
+        else:
+            setdep(dsthdr, name, version)
 
 def add_dependencies(header, module_names=None, long_python=False):
     '''Adds ``DEPNAMnn``, ``DEPVERnn`` keywords to header for imported modules.

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -201,11 +201,11 @@ def mergedep(srchdr, dsthdr, conflict='src'):
     Raises
     ------
     ValueError
-        If `conflict == 'exception'` and the same dependency name appears
+        If ``conflict == 'exception'`` and the same dependency name appears
         in both headers with different values; or if `conflict` isn't one
         of 'src', 'dst', or 'exception'.
     '''
-    if not conflict in ('src', 'dst', 'exception'):
+    if conflict not in ('src', 'dst', 'exception'):
         raise ValueError(f"conflict ({conflict}) should be 'src', 'dst', or 'exception'")
 
     for name, version in iterdep(srchdr):

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -95,6 +95,10 @@ class TestDepend(unittest.TestCase):
         self.assertEqual(getdep(src, 'blat'), getdep(dst, 'blat'))
         self.assertEqual(getdep(src, 'foo'), getdep(dst, 'foo'))
 
+        #- ... and the original unique dst versions should still be there
+        self.assertEqual(getdep(dst, 'biz'), '3.0')
+        self.assertEqual(getdep(dst, 'bat'), '4.0')
+
         #- if conflict='src', a src dependency can replace a dst dependency
         dst = dict(
             DEPNAM00='biz', DEPVER00='3.0',
@@ -119,6 +123,21 @@ class TestDepend(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             mergedep(src, dst, conflict='exception')
+
+        #- if the same version appears but is consistent, that's ok
+        for conflict in ('src', 'dst', 'exception'):
+            src = dict(
+                DEPNAM00='blat', DEPVER00='1.0',
+                DEPNAM01='foo', DEPVER01='2.0',
+            )
+            dst = dict(
+                DEPNAM00='blat', DEPVER00='1.0',
+                DEPNAM01='bat', DEPVER01='4.0',
+            )
+            mergedep(src, dst, conflict=conflict)
+            self.assertEqual(getdep(dst, 'blat'), '1.0')
+            self.assertEqual(getdep(dst, 'foo'), '2.0')
+            self.assertEqual(getdep(dst, 'bat'), '4.0')
 
     @unittest.skipUnless(test_fits_header, 'requires astropy.io.fits')
     def test_fits_header(self):

--- a/py/desiutil/test/test_depend.py
+++ b/py/desiutil/test/test_depend.py
@@ -139,6 +139,10 @@ class TestDepend(unittest.TestCase):
             self.assertEqual(getdep(dst, 'foo'), '2.0')
             self.assertEqual(getdep(dst, 'bat'), '4.0')
 
+        #- Unrecognized values of conflict result in a ValueError
+        with self.assertRaises(ValueError):
+            mergedep(src, dst, conflict='giveup')
+
     @unittest.skipUnless(test_fits_header, 'requires astropy.io.fits')
     def test_fits_header(self):
         """Test dependency functions with an actual FITS header.


### PR DESCRIPTION
This PR adds `desiutil.depend.mergedep` as a utility function to merge DEPNAMnn + DEPVERnn dependencies+versions from one header into another.  We messed this up with the blanc run by simply copying header keywords from one to the other, resulting in the same `DEPNAMnn` being listed more than once for different dependencies.  This `mergedep` function takes care of rearranging numbers as needed.  See the tests for examples.