### PR TITLE
add a function that converts SFD EBV to 'true' EBV

### DIFF
--- a/py/desiutil/dust.py
+++ b/py/desiutil/dust.py
@@ -82,6 +82,19 @@ def mwdust_transmission(ebv, band, photsys):
 
         return transmission
 
+def convert_sfd_ebv_to_true_ebv(ebv):
+    """
+    Apply the correction from Schlafly+2010
+    https://ui.adsabs.harvard.edu/abs/2010ApJ...725.1175S/abstract
+    to the input SFD E(B-V)'s 
+    to convert them into 'correct' E(B-V)'s that don't need additional 
+    scaling. This function is here to avoid hardcoding the 0.86 factor
+    in some functions that expect 'true' E(B-V)s and be more explicit 
+    about the conversion.
+    """
+    return 0.86 * ebv
+
+    
 def ext_odonnell(wave, Rv=3.1):
     """Return extinction curve from Odonnell (1994), defined in the wavelength
     range [3030,9091] Angstroms.  Outside this range, use CCM (1989).


### PR DESCRIPTION
Hi, 

To address issues raised here 
https://github.com/desihub/desispec/pull/1159

I've added a function that converts SFD EBV to 'true' EBV, in order to avoid having a 0.86 normalization number in multiple places.

(To avoid possible  problems related to diving by .86 instead of multiplying, I explicitly take input EBVs rather than just return the normalization number.)

 