### PR TITLE
Switch to pip install

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,12 @@
 Change Log
 ==========
 
-3.1.3 (unreleased)
+3.2.0 (unreleased)
 ------------------
 
-* No changes yet
+* Use ``pip install .`` instead of ``python setup.py install`` (PR `#168`_).
+
+.. _`#168`: https://github.com/desihub/desiutil/pull/168
 
 3.1.2 (2021-02-15)
 ------------------

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -57,7 +57,7 @@ Environment variables that strongly affect the behavior of :command:`desiInstall
     :command:`svn`.
 
 Environment variables that are *set* by :command:`desiInstall` for use by
-:command:`python setup.py` or :command:`make`.
+:command:`pip install` or :command:`make`.
 
 :envvar:`INSTALL_DIR`
     This variable is *set* by :command:`desiInstall` to the directory that will contain
@@ -113,7 +113,7 @@ defaults to a pre-defined value. ``$product_root`` may contain the following
 directories:
 
 code/
-    This contains the installed code, the result of :command:`python setup.py install`
+    This contains the installed code, the result of :command:`pip install .`
     or :command:`make install`.  The code is always placed in a ``product/version``
     directory.  So for example, the full path to :command:`desiInstall` might be
     ``$product_root/code/desiutil/1.8.0/bin/desiInstall``.
@@ -212,7 +212,7 @@ order and the first matching method is used:
 
 py
     If a setup.py file is detected, :command:`desiInstall` will attempt to execute
-    :command:`python setup.py install`.  This build type can be suppressed with the
+    :command:`pip install .`.  This build type can be suppressed with the
     command line option ``--compile-c``.
 make
     If a Makefile is detected, :command:`desiInstall` will attempt to execute
@@ -299,10 +299,10 @@ If the build-type is *only* 'plain', or if a branch install is
 requested, the downloaded code will be copied to :envvar:`INSTALL_DIR`.
 Further Python or C/C++ install steps described below will be skipped.
 
-Run setup.py
-------------
+Run pip
+-------
 
-If the build-type 'py' is detected, :command:`python setup.py install` will be run
+If the build-type 'py' is detected, :command:`pip install .` will be run
 at this point.
 
 Build C/C++ Code

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -52,6 +52,7 @@ known_products = {
     'LSS': 'https://github.com/desihub/LSS',
     'nightwatch': 'https://github.com/desihub/nightwatch',
     'prospect': 'https://github.com/desihub/prospect',
+    'QuasarNP': 'https://github.com/desihub/QuasarNP',
     'quicksurvey_example': 'https://github.com/desihub/quicksurvey_example',
     'redrock': 'https://github.com/desihub/redrock',
     'redrock-templates': 'https://github.com/desihub/redrock-templates',

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -26,12 +26,14 @@ from . import __version__ as desiutilVersion
 
 known_products = {
     'desiBackup': 'https://github.com/desihub/desiBackup',
+    'desicmx': 'https://github.com/desihub/desicmx',
     'desidatamodel': 'https://github.com/desihub/desidatamodel',
     'desidithering': 'https://github.com/desihub/desidithering',
     'desietc': 'https://github.com/desihub/desietc',
     'desilamps': 'https://github.com/desihub/desilamps',
     'desimeter': 'https://github.com/desihub/desimeter',
     'desimodel': 'https://github.com/desihub/desimodel',
+    'desiperf': 'https://github.com/desihub/desiperf',
     'desisim': 'https://github.com/desihub/desisim',
     'desisim-testdata': 'https://github.com/desihub/desisim-testdata',
     'desispec': 'https://github.com/desihub/desispec',
@@ -43,25 +45,37 @@ known_products = {
     'desitransfer': 'https://github.com/desihub/desitransfer',
     'desitree': 'https://github.com/desihub/desitree',
     'desiutil': 'https://github.com/desihub/desiutil',
+    'fastspecfit': 'https://github.com/desihub/fastspecfit',
     'fiberassign': 'https://github.com/desihub/fiberassign',
     'gcr-catalogs': 'https://github.com/desihub/gcr-catalogs',
     'imaginglss': 'https://github.com/desihub/imaginglss',
+    'LSS': 'https://github.com/desihub/LSS',
     'nightwatch': 'https://github.com/desihub/nightwatch',
     'prospect': 'https://github.com/desihub/prospect',
     'quicksurvey_example': 'https://github.com/desihub/quicksurvey_example',
     'redrock': 'https://github.com/desihub/redrock',
     'redrock-templates': 'https://github.com/desihub/redrock-templates',
     'specex': 'https://github.com/desihub/specex',
+    'speclite': 'https://github.com/desihub/speclite',
     'specsim': 'https://github.com/desihub/specsim',
     'specter': 'https://github.com/desihub/specter',
     'surveysim': 'https://github.com/desihub/surveysim',
     'teststand': 'https://github.com/desihub/teststand',
     'tilepicker': 'https://github.com/desihub/tilepicker',
+    'timedomain': 'https://github.com/desihub/timedomain',
     'simqso': 'https://github.com/imcgreer/simqso',
     'plate_layout': 'https://desi.lbl.gov/svn/code/focalplane/plate_layout',
     'positioner_control':
         'https://desi.lbl.gov/svn/code/focalplane/positioner_control',
     }
+
+
+pip_safe = frozenset(['desicmx', 'desidatamodel', 'desidithering', 'desietc',
+                      'desimeter', 'desimodel', 'desisim', 'desispec',
+                      'desisurvey', 'desitarget', 'desitemplate', 'desitransfer',
+                      'desiutil', 'fiberassign', 'prospect', 'redrock',
+                      'specex', 'speclite', 'specsim', 'specter', 'surveysim',
+                      'simqso'])
 
 
 def dependencies(modulefile):
@@ -798,11 +812,15 @@ class DesiInstall(object):
                 #
                 # Ready to python setup.py
                 #
-                command = [sys.executable, 'setup.py', 'install',
-                           '--prefix={0}'.format(self.install_dir)]
+                # command = [sys.executable, 'setup.py', 'install',
+                #            '--prefix={0}'.format(self.install_dir)]
+                command = [sys.executable, '-m', 'pip', 'install', '--no-deps',
+                          '--disable-pip-version-check', '--ignore-installed',
+                          '--prefix={0}'.format(self.install_dir), '.']
                 self.log.debug(' '.join(command))
                 if self.options.test:
-                    self.log.debug("Test Mode.  Skipping 'python setup.py install'.")
+                    # self.log.debug("Test Mode.  Skipping 'python setup.py install'.")
+                    self.log.debug("Test Mode. Skipping 'pip install'.")
                 else:
                     os.chdir(self.working_dir)
                     proc = Popen(command, universal_newlines=True,

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -71,12 +71,15 @@ known_products = {
     }
 
 
-pip_safe = frozenset(['desicmx', 'desidatamodel', 'desidithering', 'desietc',
-                      'desimeter', 'desimodel', 'desisim', 'desispec',
-                      'desisurvey', 'desitarget', 'desitemplate', 'desitransfer',
-                      'desiutil', 'fiberassign', 'prospect', 'redrock',
-                      'specex', 'speclite', 'specsim', 'specter', 'surveysim',
-                      'simqso'])
+#
+# Reserved for future use.
+#
+# pip_safe = frozenset(['desicmx', 'desidatamodel', 'desidithering', 'desietc',
+#                       'desimeter', 'desimodel', 'desisim', 'desispec',
+#                       'desisurvey', 'desitarget', 'desitemplate', 'desitransfer',
+#                       'desiutil', 'fiberassign', 'prospect', 'redrock',
+#                       'specex', 'speclite', 'specsim', 'specter', 'surveysim',
+#                       'simqso'])
 
 
 def dependencies(modulefile):

--- a/py/desiutil/modules.py
+++ b/py/desiutil/modules.py
@@ -77,6 +77,11 @@ def init_modules(moduleshome=None, method=False, command=False):
         if tclsh is None:
             raise ValueError("TCL Modules detected, but no tclsh excecutable found.")
         modulecmd = [tclsh, os.path.join(moduleshome, 'modulecmd.tcl'), 'python']
+    elif os.path.exists(os.path.join(moduleshome, 'libexec', 'lmod')):
+        #
+        # Lmod version!
+        #
+        modulecmd = [os.path.exists(os.path.join(moduleshome, 'libexec', 'lmod')), 'python']
     else:
         #
         # This should work on all NERSC systems, assuming the user's environment


### PR DESCRIPTION
This PR closes #167.  In addition to a simple replacement of `python setup.py install` with the equivalent `pip install .`, this PR

* Updates the known packages.
* Begins preparation for the transition to Lmod-based modules.