### PR TITLE
Ignore messages on STDERR unless there is a non-zero return code

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,11 @@ Change Log
 ------------------
 
 * Optionally compute the MW dust transmission in the WISE bands (PR `#175`_).
+* Do not treat messages printed on STDERR as errors during :command:`desiInstall` (PR `#176`_).
 
 .. _`#175`: https://github.com/desihub/desiutil/pull/175
+.. _`#176`: https://github.com/desihub/desiutil/pull/176
+
 
 3.2.2 (2021-06-03)
 ------------------

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -833,24 +833,16 @@ class DesiInstall(object):
                     self.log.debug(out)
                     if len(err) > 0:
                         #
-                        # Some warnings can be produced by processing
-                        # MANIFEST.in and not finding directories.  These
-                        # can be ignored.
+                        # Pass STDERR messages to the user, but do not
+                        # raise an error unless the return code was non-zero.
                         #
-                        manifestre = re.compile(r"(warning: |)no" +
-                                                r"( previously-included | )" +
-                                                r"(directories|files)", re.I)
-                        # manifestre = re.compile(r"no( previously-included| )" +
-                        #                         r"( directories| files)" +
-                        #                         r"( found| ) " +
-                        #                         r"matching '[^']+'")
-                        lines = [l for l in err.split('\n') if len(l) > 0 and
-                                 manifestre.search(l) is None and
-                                 'astropy_helpers' not in l and
-                                 'astropy-helpers' not in l]
-                        if len(lines) > 0:
-                            message = ("Error during installation: " +
-                                       "{0}".format("\n".join(lines)))
+                        if proc.returncode == 0:
+                            message = ("Pip emitted messages on STDERR; these can probably be ignored:\n" +
+                                       err)
+                            self.log.warning(message)
+                        else:
+                            message = ("Potentially serious error detected during pip installation:\n" +
+                                       err)
                             self.log.critical(message)
                             raise DesiInstallException(message)
             #
@@ -877,16 +869,16 @@ class DesiInstall(object):
                     self.log.debug(out)
                     if len(err) > 0:
                         #
-                        # specex emits warnings that should be ignored.
-                        # lines with -Wunused-value are emitted on all systems
-                        # lines with remark: are emitted on cori
+                        # Pass STDERR messages to the user, but do not
+                        # raise an error unless the return code was non-zero.
                         #
-                        lines = [l for l in err.split('\n') if len(l) > 0 and
-                                 '-Wunused-value' not in l and
-                                 'remark:' not in l]
-                        if len(lines) > 0:
-                            message = ("Error during compile: " +
-                                       "{0}").format("\n".join(lines))
+                        if proc.returncode == 0:
+                            message = ("Make emitted messages on STDERR; these can probably be ignored:\n" +
+                                       err)
+                            self.log.warning(message)
+                        else:
+                            message = ("Potentially serious error detected during compile:\n" +
+                                       err)
                             self.log.critical(message)
                             raise DesiInstallException(message)
         return


### PR DESCRIPTION
This PR fixes #174 by changing the logic of how messages printed on STDERR are handled by `desiInstall`.  The new logic can be summarized by this snippet:

```python
                    if len(err) > 0:
                        #
                        # Pass STDERR messages to the user, but do not
                        # raise an error unless the return code was non-zero.
                        #
                        if proc.returncode == 0:
                            message = ("Pip emitted messages on STDERR; these can probably be ignored:\n" +
                                       err)
                            self.log.warning(message)
                        else:
                            message = ("Potentially serious error detected during pip installation:\n" +
                                       err)
                            self.log.critical(message)
                            raise DesiInstallException(message)
```

@sbailey, I know you're out of the office.  Maybe @tskisner can take a quick look?  I think this will be pretty non-controversial though.