### PR TITLE
add brick_tan_wcs_size() function: compute required size of tiles

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,7 +7,7 @@ Change Log
 
 * Optionally compute the MW dust transmission in the WISE bands (PR `#175`_).
 * Do not treat messages printed on STDERR as errors during :command:`desiInstall` (PR `#176`_).
-* Add :command:`desiutil.brick.Bricks.brick_tan_wcs_size` to compute required size of TAN-projection WCS tiles (PR `#177`_)
+* Add :meth:`desiutil.brick.Bricks.brick_tan_wcs_size` to compute required size of TAN-projection WCS tiles (PR `#177`_).
 
 .. _`#175`: https://github.com/desihub/desiutil/pull/175
 .. _`#176`: https://github.com/desihub/desiutil/pull/176

--- a/py/desiutil/brick.py
+++ b/py/desiutil/brick.py
@@ -293,18 +293,25 @@ class Bricks(object):
         return xra, xdec
 
     def brick_tan_wcs_size(self):
-        """Returns the minimum required angular size (eg, pixel scale
-        x number of pixels) for a TAN WCS tiling on these brick
-        centers, so that RA1,RA2, DEC1,DEC2 land within the tile.
+        """Compute required angular size needed for WCS transformation.
+
+        Returns the minimum required angular size (pixel scale x number of pixels)
+        for a TAN WCS tiling on these brick
+        centers, so that RA1, RA2, DEC1, DEC2 land within the tile.
+
+        Returns
+        -------
+        :class:`float`
+            The angular size in degrees.
         """
         from astropy.wcs import WCS
         minx = 0
         maxx = 0
         miny = 0
         maxy = 0
-        for ras,dec1,dec2,ra,dec in zip(
-                self._edges_ra, self._edges_dec, self._edges_dec[1:],
-                self._center_ra, self._center_dec):
+        for ras, dec1, dec2, ra, dec in zip(self._edges_ra, self._edges_dec,
+                                            self._edges_dec[1:],
+                                            self._center_ra, self._center_dec):
             # We take the first column in each row (tiles in a row are all the same size)
             ra1,ra2 = ras[0],ras[1]
             ra = ra[0]

--- a/py/desiutil/test/test_brick.py
+++ b/py/desiutil/test/test_brick.py
@@ -380,6 +380,8 @@ class TestBrick(unittest.TestCase):
                     self.assertTrue((brick_table[n] == dtiling_table[n]).all())
 
     def test_tan_size(self):
+        """Test helper method for converting to WCS.
+        """
         b = B.Bricks(bricksize=1.)
         sz = b.brick_tan_wcs_size()
         self.assertAlmostEqual(sz, 1.05777777, places=6)
@@ -389,6 +391,7 @@ class TestBrick(unittest.TestCase):
         b = B.Bricks(bricksize=4.)
         sz = b.brick_tan_wcs_size()
         self.assertAlmostEqual(sz, 4.23111111, places=6)
+
 
 def test_suite():
     """Allows testing of only this module with the command::


### PR DESCRIPTION
... in order to make overlapping TAN-projection WCS tiles on brick centers

For example, a Bricks object with 0.25-degree spacing requires TAN WCS tiles at least 0.26445 degrees across to guarantee that tiles on Bricks centers will cover the entire sky without holes.
