### PR TITLE
fix pcolormesh grid deprecation warning with matplotlib 3.5

### DIFF
--- a/py/desiutil/plots.py
+++ b/py/desiutil/plots.py
@@ -715,10 +715,11 @@ def plot_grid_map(data, ra_edges, dec_edges, cmap='viridis', colorbar=True,
     # Build a 2D array of grid line intersections.
     grid_ra, grid_dec = np.meshgrid(proj_ra, ax.projection_dec(dec_edges))
 
+    ax.grid(False)
     mesh = ax.pcolormesh(grid_ra, grid_dec,
                          data, cmap=cmap, norm=norm, edgecolor='none', lw=0)
 
-    # pcolormesh turns the grid off, turn it back on.
+    # grid turned off for pcolormesh; turn it back on.
     ax.grid(True)
 
     if colorbar:


### PR DESCRIPTION
This PR avoids a deprecation warning when using matplotlib 3.5:
```
pytest py/desutil/test
...
test/test_plots.py::TestPlots::test_plot_sky_binned
  /global/common/software/desi/users/sjbailey/desiutil/py/desiutil/plots.py:718: MatplotlibDeprecationWarning: Auto-removal of grids by pcolor() and pcolormesh() is deprecated since 3.5 and will be removed two minor releases later; please call grid(False) first.
    mesh = ax.pcolormesh(grid_ra, grid_dec,
```

However, I haven't looked into what is actually happening with turning the grid off and on, so I'd appreciate a check by someone who knows what a real-world output plot is supposed to look like with this code.  @weaverba137 @dkirkby ?

This is housecleaning for a 21.12 software release for Fuji, but is low priority in the big picture.