### PR TITLE
add_dependencies includes envvars

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ Change Log
 3.2.5 (unreleased)
 ------------------
 
-* No changes yet.
+* Update :meth:`desiutil.depend.add_dependencies` to include key environment
+  variables like :envvar:`DESI_ROOT` (PR `#183`_).
+
+.. _`#183`: https://github.com/desihub/desiutil/pull/183
 
 3.2.4 (2022-01-10)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ Change Log
 3.2.5 (unreleased)
 ------------------
 
-* Update :meth:`desiutil.depend.add_dependencies` to include key environment
+* Update :func:`desiutil.depend.add_dependencies` to include key environment
   variables like :envvar:`DESI_ROOT` (PR `#183`_).
 
 .. _`#183`: https://github.com/desihub/desiutil/pull/183


### PR DESCRIPTION
This PR addresses desihub/desispec#1077 by adding the following environment variables to the suite of dependencies added by `desiutil.depend.add_dependencies`:
* DESI_ROOT
* DESI_SPECTRO_DATA
* DESI_SPECTRO_REDUX
* SPECPROD
* DESI_SPECTRO_CALIB
* DESI_BASIS_TEMPLATES
* DESI_TARGET
* DESIMODEL

this expands the concept of "dependencies" to be not just code versions but also input directories.  This list can be overridden with `envvar_names` option analogous to pre-existing `module_names` option.

I will make a companion PR on desispec to make sure we call this for every `desispec.io.write*` function, but this PR doesn't need to wait for that.

@weaverba137 if you have a chance to take a look, please do, but I plan to merge later today when I get to the point of needing this for testing.
