### PR TITLE
add gpu_specter to known packages

### DIFF
--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -60,6 +60,7 @@ known_products = {
     'speclite': 'https://github.com/desihub/speclite',
     'specsim': 'https://github.com/desihub/specsim',
     'specter': 'https://github.com/desihub/specter',
+    'gpu_specter': 'https://github.com/desihub/gpu_specter',
     'surveysim': 'https://github.com/desihub/surveysim',
     'teststand': 'https://github.com/desihub/teststand',
     'tilepicker': 'https://github.com/desihub/tilepicker',


### PR DESCRIPTION
Small update to add gpu_specter to the list of known packages.

Currently `desiInstall gpu_specter ...` correctly guesses what to do and logs a warning that it is guessing; this update just makes it so that it doesn't have to guess and thus doesn't log a harmless warning.