### PR TITLE
Update permission settings when installing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ MANIFEST
 # Other
 .*.swp
 *~
+.vscode
+.env
 
 # Mac OSX
 .DS_Store

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -274,7 +274,8 @@ Configure Module File
 :command:`desiInstall` will scan :envvar:`WORKING_DIR` to determine the details that need
 to be added to the module file.  The final module file will then be written
 into the DESI module directory at NERSC.  If ``--default`` is specified
-on the command line, an appropriate .version file will be created.
+on the command line, an appropriate .version file will be created. Module
+files are always installed with world-read permissions.
 
 Load Module
 -----------
@@ -342,7 +343,12 @@ The script itself is intended to be a thin wrapper on *e.g.*::
 Fix Permissions
 ---------------
 
-The script :command:`fix_permissions.sh` will be run on :envvar:`INSTALL_DIR`.
+The permissions of :envvar:`INSTALL_DIR` will be recursively set to standard
+values under these circumstances:
+
+1. World-read, unless ``--no-world`` is specified on the command line.
+2. Unwriteable to all, unless a branch install is being performed, in which
+   case user-write is set.
 
 Clean Up
 --------

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -211,9 +211,10 @@ possible build types that are mutually exclusive.  They are derived in this
 order and the first matching method is used:
 
 py
-    If a setup.py file is detected, :command:`desiInstall` will attempt to execute
-    :command:`pip install .`.  This build type can be suppressed with the
-    command line option ``--compile-c``.
+    If a pyproject.toml or a setup.py file is detected,
+    :command:`desiInstall` will attempt to execute :command:`pip install .`.
+    This build type can be suppressed with the command line option
+    ``--compile-c``.
 make
     If a Makefile is detected, :command:`desiInstall` will attempt to execute
     :command:`make install`.

--- a/py/desiutil/iers.py
+++ b/py/desiutil/iers.py
@@ -116,6 +116,10 @@ def freeze_iers(name='iers_frozen.ecsv', ignore_warnings=True):
     astropy.utils.iers.conf.auto_max_age = None
     astropy.utils.iers.conf.iers_auto_url = 'frozen'
     astropy.utils.iers.conf.iers_auto_url_mirror = 'frozen'
+    if ignore_warnings:
+        astropy.utils.iers.conf.iers_degraded_accuracy = 'ignore'
+    else:
+        astropy.utils.iers.conf.iers_degraded_accuracy = 'warn'
     # Sanity check.
     auto_class = astropy.utils.iers.IERS_Auto.open()
     if auto_class is not iers:

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -541,8 +541,7 @@ class DesiInstall(object):
             self.log.debug("Forcing build type: make")
             build_type.add('make')
         else:
-            if (os.path.exists(os.path.join(self.working_dir, 'pyproject.toml')) or
-                os.path.exists(os.path.join(self.working_dir, 'setup.py'))):
+            if (os.path.exists(os.path.join(self.working_dir, 'pyproject.toml')) or os.path.exists(os.path.join(self.working_dir, 'setup.py'))):
                 self.log.debug("Detected build type: py")
                 build_type.add('py')
             elif os.path.exists(os.path.join(self.working_dir, 'Makefile')):

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -10,7 +10,7 @@ This package contains code for installing DESI software products.
 import os
 import sys
 import tarfile
-import re
+import stat
 import shutil
 import requests
 from io import BytesIO
@@ -239,6 +239,9 @@ class DesiInstall(object):
                             help='Print extra information.')
         parser.add_argument('-V', '--version', action='version',
                             version='%(prog)s ' + desiutilVersion)
+        parser.add_argument('-W', '--no-world', action='store_false',
+                            dest='world',
+                            help='Disable world-readable installation.')
         parser.add_argument('product', nargs='?',
                             default='NO PACKAGE',
                             help='Name of product to install.')
@@ -966,40 +969,42 @@ class DesiInstall(object):
         return True
 
     def permissions(self):
-        """Fix possible install permission errors.
-
-        Returns
-        -------
-        :class:`int`
-            Status code returned by fix_permissions.sh script.
+        """Set permissions on installed software.
         """
-        command = ['fix_permissions.sh']
-        if self.options.verbose:
-            command.append('-v')
-        if self.options.test:
-            command.append('-t')
-        command.append(self.install_dir)
-        self.log.debug(' '.join(command))
-        proc = Popen(command, universal_newlines=True,
-                     stdout=PIPE, stderr=PIPE)
-        out, err = proc.communicate()
-        status = proc.returncode
-        self.log.debug(out)
-        #
-        # Remove write permission to avoid accidental changes
-        #
+        read_file = stat.S_IRUSR | stat.S_IRGRP
+        if self.options.world:
+            read_file |= stat.S_IROTH
+        read_exec = read_file | stat.S_IXUSR | stat.S_IXGRP
+        if self.options.world:
+            read_exec |= stat.S_IXOTH
+        read_dir = read_exec | stat.S_ISGID
         if self.is_branch:
-            chmod_mode = 'g-w,o-w'
-        else:
-            chmod_mode = 'a-w'
-        command = ['chmod', '-R', chmod_mode, self.install_dir]
-        self.log.debug(' '.join(command))
-        proc = Popen(command, universal_newlines=True,
-                     stdout=PIPE, stderr=PIPE)
-        out, err = proc.communicate()
-        chmod_status = proc.returncode
-        self.log.debug(out)
-        return status
+            read_file |= stat.S_IWUSR
+            read_exec |= stat.S_IWUSR
+            read_dir |= stat.S_IWUSR
+        #
+        # Recursively set permissions from the bottom up.
+        #
+        for dirpath, dirnames, filenames in os.walk(self.install_dir, topdown=False):
+            for f in filenames:
+                fname = os.path.join(dirpath, f)
+                if os.path.islink(fname):
+                    continue
+                executable = (stat.S_IMODE(os.stat(fname).st_mode) & stat.S_IXUSR) != 0
+                if executable:
+                    self.log.debug("os.chmod('%s', %s)", fname, read_exec)
+                    os.chmod(fname, read_exec)
+                else:
+                    self.log.debug("os.chmod('%s', %s)", fname, read_exec)
+                    os.chmod(fname, read_file)
+            for d in dirnames:
+                self.log.debug("os.chmod('%s', %s)", os.path.join(dirpath, d), read_dir)
+                os.chmod(os.path.join(dirpath, d), read_dir)
+        #
+        # Finally set permissions on the top directory.
+        #
+        self.log.debug("os.chmod('%s', %s)", self.install_dir, read_dir)
+        os.chmod(self.install_dir, read_dir)
 
     def unlock_permissions(self):
         """Unlock installed directories to allow their removal.

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -541,7 +541,8 @@ class DesiInstall(object):
             self.log.debug("Forcing build type: make")
             build_type.add('make')
         else:
-            if os.path.exists(os.path.join(self.working_dir, 'setup.py')):
+            if (os.path.exists(os.path.join(self.working_dir, 'pyproject.toml')) or
+                os.path.exists(os.path.join(self.working_dir, 'setup.py'))):
                 self.log.debug("Detected build type: py")
                 build_type.add('py')
             elif os.path.exists(os.path.join(self.working_dir, 'Makefile')):

--- a/py/desiutil/test/test_iers.py
+++ b/py/desiutil/test/test_iers.py
@@ -117,6 +117,21 @@ class TestIERS(unittest.TestCase):
         self.assertIsNone(astropy.utils.iers.conf.auto_max_age)
         self.assertEqual(astropy.utils.iers.conf.iers_auto_url, 'frozen')
         self.assertEqual(astropy.utils.iers.conf.iers_auto_url_mirror, 'frozen')
+        self.assertEqual(astropy.utils.iers.conf.iers_degraded_accuracy, 'ignore')
+        mock_logger().info.assert_has_calls([call('Freezing IERS table used by astropy time, coordinates.')])
+
+    @patch('desiutil.iers.get_logger')
+    def test_freeze_iers_ignore_warnings(self, mock_logger):
+        """Test freezing from package data/, but allow warnings.
+        """
+        i.freeze_iers(ignore_warnings=False)
+        future = Time('2024-01-01', location=self.location)
+        lst = future.sidereal_time('apparent')
+        self.assertFalse(astropy.utils.iers.conf.auto_download)
+        self.assertIsNone(astropy.utils.iers.conf.auto_max_age)
+        self.assertEqual(astropy.utils.iers.conf.iers_auto_url, 'frozen')
+        self.assertEqual(astropy.utils.iers.conf.iers_auto_url_mirror, 'frozen')
+        self.assertEqual(astropy.utils.iers.conf.iers_degraded_accuracy, 'warn')
         mock_logger().info.assert_has_calls([call('Freezing IERS table used by astropy time, coordinates.')])
 
     @patch('desiutil.iers.get_logger')

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -334,7 +334,7 @@ class TestInstall(unittest.TestCase):
         self.assertEqual(self.desiInstall.build_type, set(['plain', 'make']))
         # Create temporary files
         options = self.desiInstall.get_options(['desispec', '1.0.0'])
-        tempfiles = {'Makefile': 'make', 'setup.py': 'py'}
+        tempfiles = {'Makefile': 'make', 'pyproject.toml': 'py', 'setup.py': 'py'}
         for t in tempfiles:
             tempfile = join(self.data_dir, t)
             with open(tempfile, 'w') as tf:

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 from unittest.mock import patch, call, MagicMock, mock_open
 from os import chdir, environ, getcwd, mkdir, remove, rmdir
-from os.path import abspath, dirname, isdir, join
+from os.path import abspath, basename, isdir, join
 from shutil import rmtree
 from argparse import Namespace
 from tempfile import mkdtemp
@@ -15,6 +15,18 @@ from pkg_resources import resource_filename
 from ..log import DEBUG
 from ..install import DesiInstall, DesiInstallException, dependencies
 from .test_log import NullMemoryHandler
+
+
+def replace_stat(filename):
+    """Mock os.stat().
+    """
+    class st_mode(object):
+        def __init__(self, st_mode):
+            self.st_mode = st_mode
+
+    if basename(filename) == 'executable':
+        return st_mode(33133)
+    return st_mode(33184)
 
 
 class TestInstall(unittest.TestCase):
@@ -87,7 +99,8 @@ class TestInstall(unittest.TestCase):
                 root=None,
                 test=False,
                 username=environ['USER'],
-                verbose=False)
+                verbose=False,
+                world=True)
             options = self.desiInstall.get_options([])
             self.assertEqual(options, default_namespace)
             default_namespace.product = 'product'
@@ -439,10 +452,36 @@ class TestInstall(unittest.TestCase):
         status = self.desiInstall.start_modules()
         self.assertTrue(callable(self.desiInstall.module))
 
-    def test_module_dependencies(self):
+    @patch('desiutil.install.dependencies')
+    @patch('os.path.exists')
+    def test_module_dependencies(self, mock_exists, mock_dependencies):
         """Test module-loading dependencies.
         """
-        pass
+        mock_dependencies.return_value = ['desiutil/main', 'foobar']
+        mock_exists.return_value = True
+        options = self.desiInstall.get_options(['desispec', '1.9.5'])
+        self.desiInstall.baseproduct = 'desispec'
+        self.desiInstall.working_dir = join(self.data_dir, 'desispec')
+        self.desiInstall.module = MagicMock()
+        self.assertFalse(self.desiInstall.options.test)
+        with patch.dict('os.environ', {'LOADEDMODULES': 'desiutil'}):
+            deps = self.desiInstall.module_dependencies()
+        self.assertListEqual(self.desiInstall.deps, ['desiutil/main', 'foobar'])
+        self.assertEqual(self.desiInstall.module_file, join(self.desiInstall.working_dir, 'etc', 'desispec.module'))
+        self.desiInstall.module.assert_has_calls([call('switch', 'desiutil/main'), call('load', 'foobar')])
+        mock_exists.assert_has_calls([call(join(self.desiInstall.working_dir, 'etc', 'desispec.module'))], any_order=True)
+        mock_dependencies.assert_called_once_with(join(self.desiInstall.working_dir, 'etc', 'desispec.module'))
+
+    def test_module_dependencies_test_mode(self):
+        """Test module-loading dependencies in test mode.
+        """
+        options = self.desiInstall.get_options(['--test', 'desutil', '1.9.5'])
+        self.desiInstall.baseproduct = 'desiutil'
+        self.desiInstall.working_dir = join(self.data_dir, 'desiutil')
+        self.assertTrue(self.desiInstall.options.test)
+        deps = self.desiInstall.module_dependencies()
+        self.assertListEqual(self.desiInstall.deps, [])
+        self.assertLog(-1, 'Test Mode. Skipping loading of dependencies.')
 
     def test_nersc_module_dir(self):
         """Test the nersc_module_dir property.
@@ -574,43 +613,161 @@ exit(main())
         self.assertEqual(str(cm.exception), message)
         self.assertLog(-1, message)
 
-    @patch('desiutil.install.Popen')
-    def test_permissions(self, mock_popen):
-        """Test the permissions stage of the install.
+    @patch('os.stat', replace_stat)
+    @patch('os.walk')
+    @patch('os.chmod')
+    def test_permissions(self, mock_chmod, mock_walk):
+        """Test the permission stage of the install.
         """
-        options = self.desiInstall.get_options(['desiutil', 'branches/main'])
+        options = self.desiInstall.get_options(['desiutil', '1.2.3'])
+        self.assertTrue(self.desiInstall.options.world)
         self.desiInstall.install_dir = join(self.data_dir, 'desiutil')
         self.desiInstall.is_branch = False
-        mock_proc = mock_popen()
-        mock_proc.returncode = 0
-        mock_proc.communicate.return_value = ('out', 'err')
-        status = self.desiInstall.permissions()
-        self.assertEqual(status, 0)
-        mock_popen.assert_has_calls([call(['fix_permissions.sh', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True),
-                                     call(['chmod', '-R', 'a-w', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True)],
-                                    any_order=True)
-        mock_popen.reset_mock()
-        options = self.desiInstall.get_options(['--test', 'desiutil', 'branches/main'])
-        status = self.desiInstall.permissions()
-        self.assertEqual(status, 0)
-        mock_popen.assert_has_calls([call(['fix_permissions.sh', '-t', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True),
-                                     call(['chmod', '-R', 'a-w', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True)],
-                                    any_order=True)
-        mock_popen.reset_mock()
-        options = self.desiInstall.get_options(['--verbose', 'desiutil', 'branches/main'])
-        status = self.desiInstall.permissions()
-        self.assertEqual(status, 0)
-        mock_popen.assert_has_calls([call(['fix_permissions.sh', '-v', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True),
-                                     call(['chmod', '-R', 'a-w', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True)],
-                                    any_order=True)
-        mock_popen.reset_mock()
-        options = self.desiInstall.get_options(['--verbose', 'desiutil', 'branches/main'])
+        mock_walk.return_value = iter([(join(self.desiInstall.install_dir, 'bin'), [], ['executable', 'README.txt']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), [], ['METADATA', 'LICENSE.rst']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), [], ['__init__.cpython-3.10.pyc', 'module.cpython-3.10.pyc']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), ['__pycache__'], ['__init__.py', 'module.py']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), ['desiutil-1.2.3.dist-info', 'desiutil'], []),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10'), ['site-packages'], []),
+                                       (join(self.desiInstall.install_dir, 'lib'), ['python3.10'], []),
+                                       (self.desiInstall.install_dir, ['bin', 'lib'], [])])
+        self.desiInstall.permissions()
+        mock_walk.assert_called_once_with(self.desiInstall.install_dir, topdown=False)
+        mock_chmod.assert_has_calls([call(join(self.desiInstall.install_dir, 'bin', 'executable'), 0o555),
+                                     call(join(self.desiInstall.install_dir, 'bin', 'README.txt'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'METADATA'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'LICENSE.rst'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', '__init__.cpython-3.10.pyc'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', 'module.cpython-3.10.pyc'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__init__.py'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', 'module.py'), 0o444),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), 0o2555),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), 0o2555),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), 0o2555),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), 0o2555),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10'), 0o2555),
+                                     call(join(self.desiInstall.install_dir, 'bin'), 0o2555),
+                                     call(join(self.desiInstall.install_dir, 'lib'), 0o2555),
+                                     call(self.desiInstall.install_dir, 0o2555)])
+        self.assertLog(-2, "os.chmod('%s', %s)" % (join(self.desiInstall.install_dir, 'lib'), 0o2555))
+        self.assertLog(-1, "os.chmod('%s', %s)" % (self.desiInstall.install_dir, 0o2555))
+
+    @patch('os.stat', replace_stat)
+    @patch('os.walk')
+    @patch('os.chmod')
+    def test_permissions_with_branch(self, mock_chmod, mock_walk):
+        """Test the permission stage of the install with a branch.
+        """
+        options = self.desiInstall.get_options(['desiutil', 'branches/main'])
+        self.assertTrue(self.desiInstall.options.world)
+        self.desiInstall.install_dir = join(self.data_dir, 'desiutil')
         self.desiInstall.is_branch = True
-        status = self.desiInstall.permissions()
-        self.assertEqual(status, 0)
-        mock_popen.assert_has_calls([call(['fix_permissions.sh', '-v', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True),
-                                     call(['chmod', '-R', 'g-w,o-w', self.desiInstall.install_dir], stderr=-1, stdout=-1, universal_newlines=True)],
-                                    any_order=True)
+        mock_walk.return_value = iter([(join(self.desiInstall.install_dir, 'bin'), [], ['executable', 'README.txt']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), [], ['METADATA', 'LICENSE.rst']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), [], ['__init__.cpython-3.10.pyc', 'module.cpython-3.10.pyc']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), ['__pycache__'], ['__init__.py', 'module.py']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), ['desiutil-1.2.3.dist-info', 'desiutil'], []),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10'), ['site-packages'], []),
+                                       (join(self.desiInstall.install_dir, 'lib'), ['python3.10'], []),
+                                       (self.desiInstall.install_dir, ['bin', 'lib'], [])])
+        self.desiInstall.permissions()
+        mock_walk.assert_called_once_with(self.desiInstall.install_dir, topdown=False)
+        mock_chmod.assert_has_calls([call(join(self.desiInstall.install_dir, 'bin', 'executable'), 0o755),
+                                     call(join(self.desiInstall.install_dir, 'bin', 'README.txt'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'METADATA'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'LICENSE.rst'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', '__init__.cpython-3.10.pyc'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', 'module.cpython-3.10.pyc'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__init__.py'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', 'module.py'), 0o644),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), 0o2755),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), 0o2755),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), 0o2755),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), 0o2755),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10'), 0o2755),
+                                     call(join(self.desiInstall.install_dir, 'bin'), 0o2755),
+                                     call(join(self.desiInstall.install_dir, 'lib'), 0o2755),
+                                     call(self.desiInstall.install_dir, 0o2755)])
+        self.assertLog(-2, "os.chmod('%s', %s)" % (join(self.desiInstall.install_dir, 'lib'), 0o2755))
+        self.assertLog(-1, "os.chmod('%s', %s)" % (self.desiInstall.install_dir, 0o2755))
+
+    @patch('os.stat', replace_stat)
+    @patch('os.walk')
+    @patch('os.chmod')
+    def test_permissions_without_world(self, mock_chmod, mock_walk):
+        """Test the permission stage of the install, disabling world-read.
+        """
+        options = self.desiInstall.get_options(['--no-world', 'desiutil', '1.2.3'])
+        self.assertFalse(self.desiInstall.options.world)
+        self.desiInstall.install_dir = join(self.data_dir, 'desiutil')
+        self.desiInstall.is_branch = False
+        mock_walk.return_value = iter([(join(self.desiInstall.install_dir, 'bin'), [], ['executable', 'README.txt']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), [], ['METADATA', 'LICENSE.rst']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), [], ['__init__.cpython-3.10.pyc', 'module.cpython-3.10.pyc']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), ['__pycache__'], ['__init__.py', 'module.py']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), ['desiutil-1.2.3.dist-info', 'desiutil'], []),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10'), ['site-packages'], []),
+                                       (join(self.desiInstall.install_dir, 'lib'), ['python3.10'], []),
+                                       (self.desiInstall.install_dir, ['bin', 'lib'], [])])
+        self.desiInstall.permissions()
+        mock_walk.assert_called_once_with(self.desiInstall.install_dir, topdown=False)
+        mock_chmod.assert_has_calls([call(join(self.desiInstall.install_dir, 'bin', 'executable'), 0o550),
+                                     call(join(self.desiInstall.install_dir, 'bin', 'README.txt'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'METADATA'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'LICENSE.rst'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', '__init__.cpython-3.10.pyc'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', 'module.cpython-3.10.pyc'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__init__.py'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', 'module.py'), 0o440),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), 0o2550),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), 0o2550),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), 0o2550),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), 0o2550),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10'), 0o2550),
+                                     call(join(self.desiInstall.install_dir, 'bin'), 0o2550),
+                                     call(join(self.desiInstall.install_dir, 'lib'), 0o2550),
+                                     call(self.desiInstall.install_dir, 0o2550)])
+        self.assertLog(-2, "os.chmod('%s', %s)" % (join(self.desiInstall.install_dir, 'lib'), 0o2550))
+        self.assertLog(-1, "os.chmod('%s', %s)" % (self.desiInstall.install_dir, 0o2550))
+
+    @patch('os.stat', replace_stat)
+    @patch('os.walk')
+    @patch('os.chmod')
+    def test_permissions_with_branch_without_world(self, mock_chmod, mock_walk):
+        """Test the permission stage of the install, on a branch, disabling world-read.
+        """
+        options = self.desiInstall.get_options(['--no-world', 'desiutil', 'branches/main'])
+        self.assertFalse(self.desiInstall.options.world)
+        self.desiInstall.install_dir = join(self.data_dir, 'desiutil')
+        self.desiInstall.is_branch = True
+        mock_walk.return_value = iter([(join(self.desiInstall.install_dir, 'bin'), [], ['executable', 'README.txt']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), [], ['METADATA', 'LICENSE.rst']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), [], ['__init__.cpython-3.10.pyc', 'module.cpython-3.10.pyc']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), ['__pycache__'], ['__init__.py', 'module.py']),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), ['desiutil-1.2.3.dist-info', 'desiutil'], []),
+                                       (join(self.desiInstall.install_dir, 'lib', 'python3.10'), ['site-packages'], []),
+                                       (join(self.desiInstall.install_dir, 'lib'), ['python3.10'], []),
+                                       (self.desiInstall.install_dir, ['bin', 'lib'], [])])
+        self.desiInstall.permissions()
+        mock_walk.assert_called_once_with(self.desiInstall.install_dir, topdown=False)
+        mock_chmod.assert_has_calls([call(join(self.desiInstall.install_dir, 'bin', 'executable'), 0o750),
+                                     call(join(self.desiInstall.install_dir, 'bin', 'README.txt'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'METADATA'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info', 'LICENSE.rst'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', '__init__.cpython-3.10.pyc'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__', 'module.cpython-3.10.pyc'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__init__.py'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', 'module.py'), 0o640),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil', '__pycache__'), 0o2750),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil-1.2.3.dist-info'), 0o2750),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages', 'desiutil'), 0o2750),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10', 'site-packages'), 0o2750),
+                                     call(join(self.desiInstall.install_dir, 'lib', 'python3.10'), 0o2750),
+                                     call(join(self.desiInstall.install_dir, 'bin'), 0o2750),
+                                     call(join(self.desiInstall.install_dir, 'lib'), 0o2750),
+                                     call(self.desiInstall.install_dir, 0o2750)])
+        self.assertLog(-2, "os.chmod('%s', %s)" % (join(self.desiInstall.install_dir, 'lib'), 0o2750))
+        self.assertLog(-1, "os.chmod('%s', %s)" % (self.desiInstall.install_dir, 0o2750))
 
     @patch('desiutil.install.Popen')
     def test_unlock_permissions(self, mock_popen):

--- a/py/desiutil/test/test_modules.py
+++ b/py/desiutil/test/test_modules.py
@@ -291,6 +291,3 @@ class TestModules(unittest.TestCase):
         _write_module_data(p, 'This is a test.\n')
         self.assertEqual(S_IMODE(stat(p).st_mode), S_IRUSR | S_IRGRP | S_IROTH)
         remove(p)
-        _write_module_data(p, 'This is a test.\n', world=False)
-        self.assertEqual(S_IMODE(stat(p).st_mode), S_IRUSR | S_IRGRP)
-        remove(p)


### PR DESCRIPTION
This PR:

* Closes #192.
* Closes #194.
* Adds test coverage to other aspects of `desiInstall`.

Summarizing changes to `desiInstall`:

* Module files will always be installed world-read.
* Software files will be installed world-read, and user,group-read-only, unless:
  - ``--no-world`` is specified, in which case world-read is *disabled*.
  - A branch is installed, including `main`, in which case user-write is *enabled*.
* Internally, `fix_permissions.sh` is no longer used. In fact, no external scripts or unix commands are used to change permissions.