### PR TITLE
Add units to a Table

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,16 +23,16 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install --upgrade "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade "astropy${{ matrix.astropy-version }}"
                 python -m pip install --editable .[test]
@@ -51,16 +51,16 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install --editable .[coverage]
             - name: Run the test with coverage
               run: pytest --cov
@@ -81,15 +81,15 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel Sphinx sphinx-rtd-theme
+              run: python -m pip install --upgrade pip setuptools wheel Sphinx sphinx-rtd-theme
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 
@@ -104,15 +104,15 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel pycodestyle
+              run: python -m pip install --upgrade pip setuptools wheel pycodestyle
             - name: Test the style; failures are allowed
               # This is equivalent to an allowed falure.
               # continue-on-error: true

--- a/bin/annotate_fits
+++ b/bin/annotate_fits
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from sys import exit
+from desiutil.annotate import main
+exit(main())

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -5,6 +5,9 @@ desiutil API
 .. automodule:: desiutil
     :members:
 
+.. automodule:: desiutil.annotate
+    :members:
+
 .. automodule:: desiutil.api
     :members:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,8 +8,8 @@ desiutil API
 .. automodule:: desiutil.annotate
     :members:
 
-.. automodule:: desiutil.api
-    :members:
+.. .. automodule:: desiutil.api
+..     :members:
 
 .. automodule:: desiutil.bitmask
     :members:
@@ -53,8 +53,8 @@ desiutil API
 .. automodule:: desiutil.redirect
     :members:
 
-.. automodule:: desiutil.setup
-    :members:
+.. .. automodule:: desiutil.setup
+..     :members:
 
 .. automodule:: desiutil.sklearn
     :members:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -13,7 +13,9 @@ Change Log
 3.4.0 (unreleased)
 ------------------
 
-* Add tools for adding units to FITS table columns.
+* Add tools for adding units to table columns: FITS and :class:`~astropy.table.Table` (PR `#199`_).
+
+.. _`#199`: https://github.com/desihub/desiutil/pull/199
 
 3.3.1 (2023-06-13)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,8 +8,9 @@ Change Log
 *Planned*:
 
 * Remove deprecated commands in :mod:`desiutil.setup`.
+* Remove deprecated module :mod:`desiutil.census`.
 
-3.3.2 (unreleased)
+3.4.0 (unreleased)
 ------------------
 
 * Add tools for adding units to FITS table columns.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,7 +120,7 @@ napoleon_include_private_with_doc = True
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('numpy', 'astropy', 'matplotlib'):
+for missing in ('numpy', 'astropy', 'matplotlib', 'yaml'):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/py/desiutil/annotate.py
+++ b/py/desiutil/annotate.py
@@ -11,7 +11,10 @@ import csv
 import os
 import sys
 from argparse import ArgumentParser
+import yaml
 from astropy.io import fits
+from astropy.table import Table, QTable
+from astropy.units import UnitConversionError
 from . import __version__ as desiutilVersion
 from .log import get_logger, DEBUG
 
@@ -102,6 +105,196 @@ def csv_units(filename):
     return (units, comments)
 
 
+def yml_unit_key(data, comment=False):
+    """
+    Parameters
+    ----------
+    data : :class:`dict`
+        A dictionary resulting from a parsed YAML file.
+    comment : :class:`bool`, optional
+        If ``True``, look for a key matching 'comment'.
+
+    Returns
+    -------
+    :class:`str`
+        The key of `data` that matches.
+
+    Raises
+    ------
+    KeyError
+        If no match was found.
+    """
+    search = ('unit', )
+    if comment:
+        search = ('comment', 'description')
+    for key in data.keys():
+        for s in search:
+            if s in key.lower():
+                return key
+    raise KeyError(f"No key matching '{search[0]}' found!")
+
+
+def yml_units(filename):
+    """Parse a YAML file that contains column names and units and optionally comments.
+
+    The YAML file should contain a dictionary with a keyword like 'units' and,
+    optionally, a keyword like 'comments'.
+
+    For backwards-compatibility, the YAML file can be simply a dictionary
+    containing column names.
+
+    Parameters
+    ----------
+    filename : :class:`str` or :class:`pathlib.Path`
+        Read column definitions from `filename`.
+
+    Returns
+    -------
+    :class:`tuple`
+        A tuple containing two :class:`dict` objects for units and comments.
+        If no comments are detected, the comments :class:`dict` will be empty.
+    """
+    comments = dict()
+    # log.debug("y = yaml.safe_load('%s')", filename)
+    with open(filename, newline='') as f:
+        y = yaml.safe_load(f)
+    try:
+        u = yml_unit_key(y)
+    except KeyError:
+        log.warning(f"{filename} does not have a unit column, assuming keys are columns!")
+        u = None
+    try:
+        c = yml_unit_key(y, comment=True)
+    except KeyError:
+        c = None
+    if u:
+        units = y[u]
+    else:
+        units = y
+    if c:
+        comments = y[c]
+    return (units, comments)
+
+
+def annotate_table(table, units, comments=None, inplace=False):
+    """Add annotations to `table`.
+
+    Parameters
+    ----------
+    table : :class:`astropy.table.Table` or :class:`astropy.table.QTable`
+        A data table.
+    units : :class:`dict`
+        Mapping of table columns to units.
+    comments : :class:`dict`, optional
+        Mapping of table columns to comments.
+    inplace : :class:`bool`, optional
+        If ``True``, modify `table` directly instead of returning a copy.
+
+    Returns
+    -------
+    :class:`astropy.table.Table`
+        An updated version of `table`.
+    """
+    if inplace:
+        t = table
+    else:
+        if isinstance(table, QTable):
+            t = QTable(table)  # copy=True is the default.
+        else:
+            t = Table(table)
+    for column in units:
+        if column in t.colnames:
+            if len(units[column]) > 0:
+                try:
+                    log.debug("t['%s'].unit = '%s'", column, units[column])
+                    t[column].unit = units[column]
+                except AttributeError:
+                    #
+                    # Can't change .unit if it is already set. Try to convert.
+                    #
+                    try:
+                        log.debug("t.replace_column('%s', t['%s'].to('%s'))", column, column, units[column])
+                        t.replace_column(column, t[column].to(units[column]))
+                    except UnitConversionError:
+                        log.error("Cannot add or replace unit '%s' to column '%s'!", units[column], column)
+            else:
+                log.info("Not setting blank unit for column '%s'.", column)
+        else:
+            log.info("Column '%s' not present in table.", column)
+    return t
+
+
+def annotate(filename, extension, units=None, comments=None):
+    """Add annotations to `filename`.
+
+    If `units` or `comments` is an empty dictionary, it will be ignored.
+
+    Parameters
+    ----------
+    filename : :class:`str`
+        Name of FITS file.
+    extension : :class:`str` or :class:`int
+        Name or number of extension in `filename`.
+    units : :class:`dict`, optional
+        Mapping of table columns to units.
+    comments : :class:`dict`, optional
+        Mapping of table columns to comments.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.HDUList`
+        An updated version of the file.
+    """
+    new_hdus = list()
+    with fits.open(filename, mode='readonly', memmap=False, lazy_load_hdus=False, uint=False, disable_image_compression=True, do_not_scale_image_data=True, character_as_bytes=True, scale_back=True) as hdulist:
+        log.debug(hdulist._open_kwargs)
+        kwargs = hdulist._open_kwargs.copy()
+        for h in hdulist:
+            hc = h.copy()
+            if hasattr(h, '_do_not_scale_image_data'):
+                hc._do_not_scale_image_data = h._do_not_scale_image_data
+            if hasattr(h, '_bzero'):
+                hc._bzero = h._bzero
+            if hasattr(h, '_bscale'):
+                hc._bzero = h._bscale
+            if hasattr(h, '_scale_back'):
+                hc._scale_back = h._scale_back
+            if hasattr(h, '_uint'):
+                hc._uint = h._uint
+            #
+            # Work around header comments not copied for BinTableHDU.
+            #
+            if isinstance(h, fits.BinTableHDU):
+                for key in h.header.keys():
+                    hc.header.comments[key] = h.header.comments[key]
+            #
+            # Work around disappearing BZERO and BSCALE keywords.
+            #
+            if isinstance(h, fits.ImageHDU) and 'BZERO' in h.header and 'BSCALE' in h.header:
+                if 'BZERO' not in hc.header or 'BSCALE' not in hc.header:
+                    iscale = h.header.index('BSCALE')
+                    izero = h.header.index('BZERO')
+                    if izero > iscale:
+                        hc.header.insert(iscale - 1, ('BSCALE', h.header['BSCALE'], h.header.comments['BSCALE']), after=True)
+                        hc.header.insert(iscale, ('BZERO', h.header['BZERO'], h.header.comments['BZERO']), after=True)
+                    else:
+                        hc.header.insert(izero - 1, ('BZERO', h.header['BZERO'], h.header.comments['BZERO']), after=True)
+                        hc.header.insert(izero, ('BSCALE', h.header['BSCALE'], h.header.comments['BSCALE']), after=True)
+            new_hdus.append(hc)
+    new_hdulist = fits.HDUList(new_hdus)
+    new_hdulist._open_kwargs = kwargs
+    log.debug(new_hdulist._open_kwargs)
+    try:
+        ext = int(extension)
+    except ValueError:
+        ext = extension
+    try:
+        hdu = new_hdulist[ext]
+    except (IndexError, KeyError):
+        raise
+    return new_hdulist
+
+
 def _options():
     """Parse command-line options.
     """
@@ -113,6 +306,8 @@ def _options():
                         help="Read annotations from CSV file.")
     parser.add_argument('-e', '--extension', dest='extension', action='store', metavar='EXT', default='1',
                         help="Update FITS extension EXT, which can be a number or an EXTNAME. If not specified, HDU 1 will be updated, which is standard for simple binary tables.")
+    parser.add_argument('-o', '--overwrite', dest='overwrite', action='store_true',
+                        help='Overwrite the input FITS file.')
     parser.add_argument('-t', '--test', dest='test', action='store_true',
                         help='Test mode; show what would be done but do not change any files.')
     parser.add_argument('-u', '--units', action='store', dest='units', metavar='UNITS',
@@ -120,6 +315,11 @@ def _options():
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help='Print extra debugging information.')
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + desiutilVersion)
+    parser.add_argument('-Y', '--yaml', action='store', dest='yaml', metavar='YAML',
+                        help="Read annotations from YAML file.")
+    parser.add_argument('fits', metavar='FITS', help='FITS file to modify.')
+    parser.add_argument('output', metavar='FITS', nargs='?',
+                        help='Write to new FITS file. If --overwrite is specified, this value is ignored.')
     options = parser.parse_args()
     return options
 
@@ -140,6 +340,8 @@ def main():
         log = get_logger()
     if options.csv:
         units, comments = csv_units(options.csv)
+    elif options.yaml:
+        units, comments = yml_units(options.yaml)
     else:
         if options.units:
             units = dict(tuple(c.split('=')) for c in options.units.split(':'))
@@ -151,6 +353,24 @@ def main():
         else:
             log.debug("No comments have been specified.")
             comments = dict()
-    log.debug(units)
-    log.debug(comments)
+    log.debug("units = %s", units)
+    log.debug("comments = %s", comments)
+    hdulist = annotate(options.fits, options.extension, units, comments)
+    if options.overwrite and options.output:
+        output = options.output
+    elif options.overwrite:
+        output = options.fits
+    elif options.output:
+        output = options.output
+    else:
+        log.error("--overwrite not specified and no output file specified!")
+        return 1
+    try:
+        hdulist.writeto(output, output_verify='warn', overwrite=options.overwrite, checksum=False)
+    except OSError as e:
+        if 'overwrite' in e.args[0]:
+            log.error("Output file exists and --overwrite was not specified!")
+        else:
+            log.error(e.args[0])
+        return 1
     return 0

--- a/py/desiutil/annotate.py
+++ b/py/desiutil/annotate.py
@@ -19,9 +19,6 @@ from . import __version__ as desiutilVersion
 from .log import get_logger, DEBUG
 
 
-log = None
-
-
 def find_column_name(columns, prefix=('unit', )):
     """Find the column that contains unit descriptions, or comments.
 
@@ -100,6 +97,7 @@ def load_csv_units(filename):
     ValueError
         If `filename` does not at least contain a "unit" column.
     """
+    log = get_logger()
     units = dict()
     comments = dict()
     header = None
@@ -150,6 +148,7 @@ def load_yml_units(filename):
         A tuple containing two :class:`dict` objects for units and comments.
         If no comments are detected, the comments :class:`dict` will be empty.
     """
+    log=get_logger()
     comments = dict()
     # log.debug("y = yaml.safe_load('%s')", filename)
     with open(filename, newline='') as f:
@@ -196,6 +195,7 @@ def annotate_table(table, units, inplace=False):
     could be written to a file. If this ever changes, this function could
     be extended to add comments.
     """
+    log = get_logger()
     if inplace:
         t = table
     else:
@@ -249,6 +249,7 @@ def annotate(filename, extension, units=None, comments=None):
     :class:`astropy.io.fits.HDUList`
         An updated version of the file.
     """
+    log = get_logger()
     new_hdus = list()
     with fits.open(filename, mode='readonly', memmap=False, lazy_load_hdus=False, uint=False, disable_image_compression=True, do_not_scale_image_data=True, character_as_bytes=True, scale_back=True) as hdulist:
         log.debug(hdulist._open_kwargs)
@@ -336,7 +337,6 @@ def main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
-    global log
     options = _options()
     if options.test or options.verbose:
         log = get_logger(DEBUG)

--- a/py/desiutil/annotate.py
+++ b/py/desiutil/annotate.py
@@ -148,7 +148,7 @@ def load_yml_units(filename):
         A tuple containing two :class:`dict` objects for units and comments.
         If no comments are detected, the comments :class:`dict` will be empty.
     """
-    log=get_logger()
+    log = get_logger()
     comments = dict()
     # log.debug("y = yaml.safe_load('%s')", filename)
     with open(filename, newline='') as f:

--- a/py/desiutil/annotate.py
+++ b/py/desiutil/annotate.py
@@ -1,0 +1,156 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+=================
+desiutil.annotate
+=================
+
+Tools for adding units and comments to FITS files.
+"""
+import csv
+import os
+import sys
+from argparse import ArgumentParser
+from astropy.io import fits
+from . import __version__ as desiutilVersion
+from .log import get_logger, DEBUG
+
+
+log = None
+
+
+def csv_unit_column(header, comment=False):
+    """Find the column that contains unit descriptions, or comments.
+
+    Parameters
+    ----------
+    header : iterable
+        The column names from a CSV file.
+    comment : :class:`bool`, optional
+        If ``True``, look for a column matching 'comment'.
+
+    Returns
+    -------
+    :class:`int`
+        The index of `header` that matches.
+
+    Raises
+    ------
+    IndexError
+        If no match was found.
+    """
+    search = ('unit', )
+    if comment:
+        search = ('comment', 'description')
+    for i, column in enumerate(header):
+        for s in search:
+            if s in column.lower():
+                return i
+    raise IndexError(f"No column matching '{search[0]}' found!")
+
+
+def csv_units(filename):
+    """Parse a CSV file that contains column names and units and optionally comments.
+
+    Table column names are assumed to be in the first column of the CSV file.
+    Any column with the name "Unit(s)" (case-insensitive) is assumed to contain FITS-style units.
+    Any column with the name "Comment(s)" (case-insensitive) is assumed to be the comment.
+
+    Parameters
+    ----------
+    filename : :class:`str` or :class:`pathlib.Path`
+        Read column definitions from `filename`.
+
+    Returns
+    -------
+    :class:`tuple`
+        A tuple containing two :class:`dict` objects for units and comments.
+        If no comments are detected, the comments :class:`dict` will be empty.
+
+    Raises
+    ------
+    ValueError
+        If `filename` does not at least contain a "unit" column.
+    """
+    units = dict()
+    comments = dict()
+    header = None
+    data = list()
+    log.debug("filename = '%s'", filename)
+    with open(filename, newline='') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if header is None:
+                header = row
+            else:
+                data.append(row)
+    log.debug(header)
+    try:
+        u = csv_unit_column(header)
+    except IndexError:
+        raise ValueError(f"{filename} does not have a unit column!")
+    try:
+        c = csv_unit_column(header, comment=True)
+    except IndexError:
+        c = None
+    for row in data:
+        log.debug("units['%s'] = '%s'", row[0], row[u])
+        units[row[0]] = row[u]
+        if c:
+            log.debug("comments['%s'] = '%s'", row[0], row[c])
+            comments[row[0]] = row[c]
+    return (units, comments)
+
+
+def _options():
+    """Parse command-line options.
+    """
+    parser = ArgumentParser(description="Add units or comments to a FITS file.",
+                            prog=os.path.basename(sys.argv[0]))
+    parser.add_argument('-c', '--comments', action='store', dest='comments', metavar='COMMENTS',
+                        help="COMMENTS should have the form COLUMN='comment':COLUMN='comment'.")
+    parser.add_argument('-C', '--csv', action='store', dest='csv', metavar='CSV',
+                        help="Read annotations from CSV file.")
+    parser.add_argument('-e', '--extension', dest='extension', action='store', metavar='EXT', default='1',
+                        help="Update FITS extension EXT, which can be a number or an EXTNAME. If not specified, HDU 1 will be updated, which is standard for simple binary tables.")
+    parser.add_argument('-t', '--test', dest='test', action='store_true',
+                        help='Test mode; show what would be done but do not change any files.')
+    parser.add_argument('-u', '--units', action='store', dest='units', metavar='UNITS',
+                        help="UNITS should have the form COLUMN='unit':COLUMN='unit'.")
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
+                        help='Print extra debugging information.')
+    parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + desiutilVersion)
+    options = parser.parse_args()
+    return options
+
+
+def main():
+    """Entry-point for command-line scripts.
+
+    Returns
+    -------
+    :class:`int`
+        An integer suitable for passing to :func:`sys.exit`.
+    """
+    global log
+    options = _options()
+    if options.test or options.verbose:
+        log = get_logger(DEBUG)
+    else:
+        log = get_logger()
+    if options.csv:
+        units, comments = csv_units(options.csv)
+    else:
+        if options.units:
+            units = dict(tuple(c.split('=')) for c in options.units.split(':'))
+        else:
+            log.warning("No units have been specified!")
+            units = dict()
+        if options.comments:
+            comments = dict(tuple(c.split('=')) for c in options.comments.split(':'))
+        else:
+            log.debug("No comments have been specified.")
+            comments = dict()
+    log.debug(units)
+    log.debug(comments)
+    return 0

--- a/py/desiutil/annotate.py
+++ b/py/desiutil/annotate.py
@@ -233,7 +233,7 @@ def annotate(filename, extension, units=None, comments=None):
     ----------
     filename : :class:`str`
         Name of FITS file.
-    extension : :class:`str` or :class:`int
+    extension : :class:`str` or :class:`int`
         Name or number of extension in `filename`.
     units : :class:`dict`, optional
         Mapping of table columns to units.

--- a/py/desiutil/annotate.py
+++ b/py/desiutil/annotate.py
@@ -237,7 +237,7 @@ def annotate(filename, extension, units=None, comments=None):
     ----------
     filename : :class:`str`
         Name of FITS file.
-    extension : :class:`str` or :class:`int
+    extension : :class:`str` or :class:`int`
         Name or number of extension in `filename`.
     units : :class:`dict`, optional
         Mapping of table columns to units.

--- a/py/desiutil/test/test_annotate.py
+++ b/py/desiutil/test/test_annotate.py
@@ -28,7 +28,7 @@ class TestAnnotate(unittest.TestCase):
         options = _options()
         self.assertTrue(options.verbose)
         self.assertIsNone(options.csv)
-        self.assertEqual(options.extension, '0')
+        self.assertEqual(options.extension, '1')
 
     def test_csv_unit_column(self):
         """Test identification of unit column.

--- a/py/desiutil/test/test_annotate.py
+++ b/py/desiutil/test/test_annotate.py
@@ -1,0 +1,92 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.annotate.
+"""
+import os
+import unittest
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+from ..annotate import csv_unit_column, csv_units, _options
+
+
+class TestAnnotate(unittest.TestCase):
+    """Test desiutil.annotate.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = TemporaryDirectory()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    @patch('sys.argv', ['annotate_fits', '--verbose'])
+    def test_options(self):
+        """Test command-line arguments.
+        """
+        options = _options()
+        self.assertTrue(options.verbose)
+        self.assertIsNone(options.csv)
+        self.assertEqual(options.extension, '0')
+
+    def test_csv_unit_column(self):
+        """Test identification of unit column.
+        """
+        self.assertEqual(csv_unit_column(['name', 'unit', 'foo', 'bar']), 1)
+        self.assertEqual(csv_unit_column(['name', 'Comments', 'foo', 'bar'], comment=True), 1)
+        self.assertEqual(csv_unit_column(['Name', 'Type', 'Units', 'Comments', 'bar'], comment=True), 3)
+        self.assertEqual(csv_unit_column(['Name', 'Type', 'Units', 'Description'], comment=True), 3)
+        with self.assertRaises(IndexError) as e:
+            c = csv_unit_column(['Name', 'stuff', 'foo', 'Comments'])
+        self.assertEqual(str(e.exception), "No column matching 'unit' found!")
+        with self.assertRaises(IndexError) as e:
+            c = csv_unit_column(['Name', 'unit', 'foo', 'bar'], comment=True)
+        self.assertEqual(str(e.exception), "No column matching 'comment' found!")
+
+    @patch('desiutil.annotate.log')
+    def test_csv_units(self, mock_log):
+        """Test parsing of units in a CSV file.
+        """
+        c = """Name,Type,Unit,Comment
+COLUMN1,int16,,This is a comment.
+RA,float32,deg,Right Ascension
+DEC,float32,deg,Declination"""
+        unitsFile = os.path.join(self.tmp.name, 'test_one.csv')
+        with open(unitsFile, 'w', newline='') as f:
+            f.write(c)
+        units, comments = csv_units(unitsFile)
+        self.assertEqual(units['RA'], 'deg')
+        self.assertEqual(units['COLUMN1'], '')
+        self.assertEqual(comments['COLUMN1'], 'This is a comment.')
+
+    @patch('desiutil.annotate.log')
+    def test_csv_units_no_comment(self, mock_log):
+        """Test parsing of units in a CSV file without comments.
+        """
+        c = """Name,Type,Unit
+COLUMN1,int16,
+RA,float32,deg
+DEC,float32,deg"""
+        unitsFile = os.path.join(self.tmp.name, 'test_two.csv')
+        with open(unitsFile, 'w', newline='') as f:
+            f.write(c)
+        units, comments = csv_units(unitsFile)
+        self.assertEqual(units['RA'], 'deg')
+        self.assertEqual(units['COLUMN1'], '')
+        self.assertFalse(bool(comments))
+
+    @patch('desiutil.annotate.log')
+    def test_csv_units_no_units(self, mock_log):
+        """Test parsing of units in a CSV file with bad units.
+        """
+        c = """Name,Type,Foobar
+COLUMN1,int16,
+RA,float32,deg
+DEC,float32,deg"""
+        unitsFile = os.path.join(self.tmp.name, 'test_three.csv')
+        with open(unitsFile, 'w', newline='') as f:
+            f.write(c)
+        with self.assertRaises(ValueError) as e:
+            units, comments = csv_units(unitsFile)
+        self.assertEqual(str(e.exception), f"{unitsFile} does not have a unit column!")

--- a/py/desiutil/test/test_annotate.py
+++ b/py/desiutil/test/test_annotate.py
@@ -61,7 +61,7 @@ class TestAnnotate(unittest.TestCase):
             k = find_key_name({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}, prefix=('comment', 'description'))
         self.assertEqual(e.exception.args[0], "No key matching 'comment' found!")
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_load_csv_units(self, mock_log):
         """Test parsing of units in a CSV file.
         """
@@ -77,7 +77,7 @@ DEC,float32,deg,Declination"""
         self.assertEqual(units['COLUMN1'], '')
         self.assertEqual(comments['COLUMN1'], 'This is a comment.')
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_load_csv_units_no_comment(self, mock_log):
         """Test parsing of units in a CSV file without comments.
         """
@@ -93,7 +93,7 @@ DEC,float32,deg"""
         self.assertEqual(units['COLUMN1'], '')
         self.assertFalse(bool(comments))
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_load_csv_units_no_units(self, mock_log):
         """Test parsing of units in a CSV file with bad units.
         """
@@ -108,7 +108,7 @@ DEC,float32,deg"""
             units, comments = load_csv_units(unitsFile)
         self.assertEqual(str(e.exception), f"{unitsFile} does not have a unit column!")
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_load_yml_units(self, mock_log):
         """Test parsing of YAML input.
         """
@@ -124,9 +124,9 @@ DEC,float32,deg"""
         self.assertEqual(units['RA'], 'deg')
         self.assertIsNone(units['COLUMN'])
         self.assertFalse(bool(comments))
-        mock_log.warning.assert_not_called()
+        mock_log().warning.assert_not_called()
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_load_yml_units_backward(self, mock_log):
         """Test parsing of older-style YAML input.
         """
@@ -141,9 +141,9 @@ COLUMN:
         self.assertEqual(units['RA'], 'deg')
         self.assertIsNone(units['COLUMN'])
         self.assertFalse(bool(comments))
-        mock_log.warning.assert_called_once_with(f'{unitsFile} does not have a unit column, assuming keys are columns!')
+        mock_log().warning.assert_called_once_with(f'{unitsFile} does not have a unit column, assuming keys are columns!')
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_load_yml_units_comments(self, mock_log):
         """Test parsing of YAML input with units and comments.
         """
@@ -162,9 +162,9 @@ Comments:
         units, comments = load_yml_units(unitsFile)
         self.assertEqual(comments['RA'], 'deg')
         self.assertEqual(comments['COLUMN'], 'dimensionless')
-        mock_log.warning.assert_not_called()
+        mock_log().warning.assert_not_called()
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_annotate_table(self, mock_log):
         """Test adding units to table columns.
         """
@@ -178,14 +178,14 @@ Comments:
         tt = annotate_table(t, u)
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
-        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
+        mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
                                          call("t['%s'].unit = '%s'", 'b', 'deg'),
                                          call("Not setting blank unit for column '%s'.", 'c'),
                                          call("Not setting blank unit for column '%s'.", 'd'),
                                          call("Column '%s' not present in table.", 'e')])
-        mock_log.info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
+        mock_log().info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_annotate_table_inplace(self, mock_log):
         """Test adding units to table columns.
         """
@@ -200,7 +200,7 @@ Comments:
         self.assertEqual(t['b'].unit, 'deg')
         self.assertIs(t, tt)
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_annotate_qtable(self, mock_log):
         """Test adding units to qtable columns.
         """
@@ -214,14 +214,14 @@ Comments:
         tt = annotate_table(t, u)
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
-        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
+        mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
                                          call("t['%s'].unit = '%s'", 'b', 'deg'),
                                          call("Not setting blank unit for column '%s'.", 'c'),
                                          call("Not setting blank unit for column '%s'.", 'd'),
                                          call("Column '%s' not present in table.", 'e')])
-        mock_log.info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
+        mock_log().info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_annotate_qtable_with_units_present(self, mock_log):
         """Test adding units to table columns with existing units.
         """
@@ -235,15 +235,15 @@ Comments:
         tt = annotate_table(t, u)
         self.assertEqual(tt['a'].unit, 'cm')
         self.assertEqual(tt['b'].unit, 'deg')
-        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'cm'),
+        mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'cm'),
                                          call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'cm'),
                                          call("t['%s'].unit = '%s'", 'b', 'deg'),
                                          call("Not setting blank unit for column '%s'.", 'c'),
                                          call("Not setting blank unit for column '%s'.", 'd'),
                                          call("Column '%s' not present in table.", 'e')])
-        mock_log.info.assert_not_called()
+        mock_log().info.assert_not_called()
 
-    @patch('desiutil.annotate.log')
+    @patch('desiutil.annotate.get_logger')
     def test_annotate_qtable_with_units_present_bad_conversion(self, mock_log):
         """Test adding units to table columns with existing units.
         """
@@ -257,11 +257,11 @@ Comments:
         tt = annotate_table(t, u)
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
-        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'A'),
+        mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'A'),
                                          call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'A'),
                                          call("t['%s'].unit = '%s'", 'b', 'deg'),
                                          call("Not setting blank unit for column '%s'.", 'c'),
                                          call("Not setting blank unit for column '%s'.", 'd'),
                                          call("Column '%s' not present in table.", 'e')])
-        mock_log.info.assert_not_called()
-        mock_log.error.assert_has_calls([call("Cannot add or replace unit '%s' to column '%s'!", 'A', 'a')])
+        mock_log().info.assert_not_called()
+        mock_log().error.assert_has_calls([call("Cannot add or replace unit '%s' to column '%s'!", 'A', 'a')])

--- a/py/desiutil/test/test_annotate.py
+++ b/py/desiutil/test/test_annotate.py
@@ -179,10 +179,10 @@ Comments:
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
-                                         call("Not setting blank unit for column '%s'.", 'c'),
-                                         call("Not setting blank unit for column '%s'.", 'd'),
-                                         call("Column '%s' not present in table.", 'e')])
+                                           call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                           call("Not setting blank unit for column '%s'.", 'c'),
+                                           call("Not setting blank unit for column '%s'.", 'd'),
+                                           call("Column '%s' not present in table.", 'e')])
         mock_log().info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
 
     @patch('desiutil.annotate.get_logger')
@@ -215,10 +215,10 @@ Comments:
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
-                                         call("Not setting blank unit for column '%s'.", 'c'),
-                                         call("Not setting blank unit for column '%s'.", 'd'),
-                                         call("Column '%s' not present in table.", 'e')])
+                                           call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                           call("Not setting blank unit for column '%s'.", 'c'),
+                                           call("Not setting blank unit for column '%s'.", 'd'),
+                                           call("Column '%s' not present in table.", 'e')])
         mock_log().info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
 
     @patch('desiutil.annotate.get_logger')
@@ -236,11 +236,11 @@ Comments:
         self.assertEqual(tt['a'].unit, 'cm')
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'cm'),
-                                         call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'cm'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
-                                         call("Not setting blank unit for column '%s'.", 'c'),
-                                         call("Not setting blank unit for column '%s'.", 'd'),
-                                         call("Column '%s' not present in table.", 'e')])
+                                           call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'cm'),
+                                           call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                           call("Not setting blank unit for column '%s'.", 'c'),
+                                           call("Not setting blank unit for column '%s'.", 'd'),
+                                           call("Column '%s' not present in table.", 'e')])
         mock_log().info.assert_not_called()
 
     @patch('desiutil.annotate.get_logger')
@@ -258,10 +258,10 @@ Comments:
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log().debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'A'),
-                                         call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'A'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
-                                         call("Not setting blank unit for column '%s'.", 'c'),
-                                         call("Not setting blank unit for column '%s'.", 'd'),
-                                         call("Column '%s' not present in table.", 'e')])
+                                           call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'A'),
+                                           call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                           call("Not setting blank unit for column '%s'.", 'c'),
+                                           call("Not setting blank unit for column '%s'.", 'd'),
+                                           call("Column '%s' not present in table.", 'e')])
         mock_log().info.assert_not_called()
         mock_log().error.assert_has_calls([call("Cannot add or replace unit '%s' to column '%s'!", 'A', 'a')])

--- a/py/desiutil/test/test_annotate.py
+++ b/py/desiutil/test/test_annotate.py
@@ -5,8 +5,10 @@
 import os
 import unittest
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
-from ..annotate import csv_unit_column, csv_units, _options
+from unittest.mock import patch, call
+import numpy as np
+from astropy.table import Table, QTable
+from ..annotate import annotate_table, csv_unit_column, csv_units, yml_unit_key, yml_units, _options
 
 
 class TestAnnotate(unittest.TestCase):
@@ -21,7 +23,7 @@ class TestAnnotate(unittest.TestCase):
     def tearDownClass(cls):
         cls.tmp.cleanup()
 
-    @patch('sys.argv', ['annotate_fits', '--verbose'])
+    @patch('sys.argv', ['annotate_fits', '--verbose', 'fits_file.fits'])
     def test_options(self):
         """Test command-line arguments.
         """
@@ -29,6 +31,7 @@ class TestAnnotate(unittest.TestCase):
         self.assertTrue(options.verbose)
         self.assertIsNone(options.csv)
         self.assertEqual(options.extension, '1')
+        self.assertEqual(options.fits, 'fits_file.fits')
 
     def test_csv_unit_column(self):
         """Test identification of unit column.
@@ -39,10 +42,10 @@ class TestAnnotate(unittest.TestCase):
         self.assertEqual(csv_unit_column(['Name', 'Type', 'Units', 'Description'], comment=True), 3)
         with self.assertRaises(IndexError) as e:
             c = csv_unit_column(['Name', 'stuff', 'foo', 'Comments'])
-        self.assertEqual(str(e.exception), "No column matching 'unit' found!")
+        self.assertEqual(e.exception.args[0], "No column matching 'unit' found!")
         with self.assertRaises(IndexError) as e:
             c = csv_unit_column(['Name', 'unit', 'foo', 'bar'], comment=True)
-        self.assertEqual(str(e.exception), "No column matching 'comment' found!")
+        self.assertEqual(e.exception.args[0], "No column matching 'comment' found!")
 
     @patch('desiutil.annotate.log')
     def test_csv_units(self, mock_log):
@@ -90,3 +93,169 @@ DEC,float32,deg"""
         with self.assertRaises(ValueError) as e:
             units, comments = csv_units(unitsFile)
         self.assertEqual(str(e.exception), f"{unitsFile} does not have a unit column!")
+
+    def test_yml_unit_key(self):
+        """Test identification of unit column in YAML.
+        """
+        self.assertEqual(yml_unit_key({'unit': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}}), 'unit')
+        self.assertEqual(yml_unit_key({'Units': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}}), 'Units')
+        self.assertEqual(yml_unit_key({'comment': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': 'foo'}}, comment=True), 'comment')
+        self.assertEqual(yml_unit_key({'DESCRIPTION': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': 'foo'}}, comment=True), 'DESCRIPTION')
+        with self.assertRaises(KeyError) as e:
+            k = yml_unit_key({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None})
+        self.assertEqual(e.exception.args[0], "No key matching 'unit' found!")
+        with self.assertRaises(KeyError) as e:
+            k = yml_unit_key({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}, comment=True)
+        self.assertEqual(e.exception.args[0], "No key matching 'comment' found!")
+
+    @patch('desiutil.annotate.log')
+    def test_yml_units(self, mock_log):
+        """Test parsing of YAML input.
+        """
+        y = """unit:
+    RA: deg
+    DEC: deg
+    COLUMN:
+"""
+        unitsFile = os.path.join(self.tmp.name, 'test_one.yml')
+        with open(unitsFile, 'w', newline='') as f:
+            f.write(y)
+        units, comments = yml_units(unitsFile)
+        self.assertEqual(units['RA'], 'deg')
+        self.assertIsNone(units['COLUMN'])
+        self.assertFalse(bool(comments))
+        mock_log.warning.assert_not_called()
+
+    @patch('desiutil.annotate.log')
+    def test_yml_units_backward(self, mock_log):
+        """Test parsing of older-style YAML input.
+        """
+        y = """RA: deg
+DEC: deg
+COLUMN:
+"""
+        unitsFile = os.path.join(self.tmp.name, 'test_one.yml')
+        with open(unitsFile, 'w', newline='') as f:
+            f.write(y)
+        units, comments = yml_units(unitsFile)
+        self.assertEqual(units['RA'], 'deg')
+        self.assertIsNone(units['COLUMN'])
+        self.assertFalse(bool(comments))
+        mock_log.warning.assert_called_once_with(f'{unitsFile} does not have a unit column, assuming keys are columns!')
+
+    @patch('desiutil.annotate.log')
+    def test_yml_units_comments(self, mock_log):
+        """Test parsing of YAML input with units and comments.
+        """
+        y = """unit:
+    RA: deg
+    DEC: deg
+    COLUMN:
+Comments:
+    RA: deg
+    DEC: deg
+    COLUMN: dimensionless
+"""
+        unitsFile = os.path.join(self.tmp.name, 'test_one.yml')
+        with open(unitsFile, 'w', newline='') as f:
+            f.write(y)
+        units, comments = yml_units(unitsFile)
+        self.assertEqual(comments['RA'], 'deg')
+        self.assertEqual(comments['COLUMN'], 'dimensionless')
+        mock_log.warning.assert_not_called()
+
+    @patch('desiutil.annotate.log')
+    def test_annotate_table(self, mock_log):
+        """Test adding units to table columns.
+        """
+        t = Table()
+        t['a'] = [1.0, 4.0]
+        t['b'] = [2.14, 5.67]
+        t['c'] = ['x', 'y']
+        t['d'] = np.array([123, 456], dtype=np.uint64)
+        u = {'a': 'm', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
+        tt = annotate_table(t, u)
+        self.assertEqual(tt['a'].unit, 'm')
+        self.assertEqual(tt['b'].unit, 'deg')
+        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
+                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
+        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
+                                        call("Not setting blank unit for column '%s'.", 'd'),
+                                        call("Column '%s' not present in table.", 'e')])
+
+    @patch('desiutil.annotate.log')
+    def test_annotate_table_inplace(self, mock_log):
+        """Test adding units to table columns.
+        """
+        t = Table()
+        t['a'] = [1.0, 4.0]
+        t['b'] = [2.14, 5.67]
+        t['c'] = ['x', 'y']
+        t['d'] = np.array([123, 456], dtype=np.uint64)
+        u = {'a': 'm', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
+        tt = annotate_table(t, u, inplace=True)
+        self.assertEqual(t['a'].unit, 'm')
+        self.assertEqual(t['b'].unit, 'deg')
+        self.assertIs(t, tt)
+
+    @patch('desiutil.annotate.log')
+    def test_annotate_qtable(self, mock_log):
+        """Test adding units to qtable columns.
+        """
+        t = QTable()
+        t['a'] = [1.0, 4.0]
+        t['b'] = [2.14, 5.67]
+        t['c'] = ['x', 'y']
+        t['d'] = np.array([123, 456], dtype=np.uint64)
+        u = {'a': 'm', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
+        tt = annotate_table(t, u)
+        self.assertEqual(tt['a'].unit, 'm')
+        self.assertEqual(tt['b'].unit, 'deg')
+        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
+                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
+        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
+                                        call("Not setting blank unit for column '%s'.", 'd'),
+                                        call("Column '%s' not present in table.", 'e')])
+
+    @patch('desiutil.annotate.log')
+    def test_annotate_qtable_with_units_present(self, mock_log):
+        """Test adding units to table columns with existing units.
+        """
+        t = QTable()
+        t['a'] = [1.0, 4.0]
+        t['b'] = [2.14, 5.67]
+        t['c'] = ['x', 'y']
+        t['d'] = np.array([123, 456], dtype=np.uint64)
+        t['a'].unit = 'm'
+        u = {'a': 'cm', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
+        tt = annotate_table(t, u)
+        self.assertEqual(tt['a'].unit, 'cm')
+        self.assertEqual(tt['b'].unit, 'deg')
+        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'cm'),
+                                         call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'cm'),
+                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
+        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
+                                        call("Not setting blank unit for column '%s'.", 'd'),
+                                        call("Column '%s' not present in table.", 'e')])
+
+    @patch('desiutil.annotate.log')
+    def test_annotate_qtable_with_units_present_bad_conversion(self, mock_log):
+        """Test adding units to table columns with existing units.
+        """
+        t = QTable()
+        t['a'] = [1.0, 4.0]
+        t['b'] = [2.14, 5.67]
+        t['c'] = ['x', 'y']
+        t['d'] = np.array([123, 456], dtype=np.uint64)
+        t['a'].unit = 'm'
+        u = {'a': 'A', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
+        tt = annotate_table(t, u)
+        self.assertEqual(tt['a'].unit, 'm')
+        self.assertEqual(tt['b'].unit, 'deg')
+        mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'A'),
+                                         call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'A'),
+                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
+        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
+                                        call("Not setting blank unit for column '%s'.", 'd'),
+                                        call("Column '%s' not present in table.", 'e')])
+        mock_log.error.assert_has_calls([call("Cannot add or replace unit '%s' to column '%s'!", 'A', 'a')])

--- a/py/desiutil/test/test_annotate.py
+++ b/py/desiutil/test/test_annotate.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch, call
 import numpy as np
 from astropy.table import Table, QTable
-from ..annotate import annotate_table, csv_unit_column, csv_units, yml_unit_key, yml_units, _options
+from ..annotate import annotate_table, find_column_name, find_key_name, load_csv_units, load_yml_units, _options
 
 
 class TestAnnotate(unittest.TestCase):
@@ -33,22 +33,36 @@ class TestAnnotate(unittest.TestCase):
         self.assertEqual(options.extension, '1')
         self.assertEqual(options.fits, 'fits_file.fits')
 
-    def test_csv_unit_column(self):
+    def test_find_column_name(self):
         """Test identification of unit column.
         """
-        self.assertEqual(csv_unit_column(['name', 'unit', 'foo', 'bar']), 1)
-        self.assertEqual(csv_unit_column(['name', 'Comments', 'foo', 'bar'], comment=True), 1)
-        self.assertEqual(csv_unit_column(['Name', 'Type', 'Units', 'Comments', 'bar'], comment=True), 3)
-        self.assertEqual(csv_unit_column(['Name', 'Type', 'Units', 'Description'], comment=True), 3)
+        self.assertEqual(find_column_name(['name', 'unit', 'foo', 'bar']), 1)
+        self.assertEqual(find_column_name(['name', 'Comments', 'foo', 'bar'], prefix=('comment', 'description')), 1)
+        self.assertEqual(find_column_name(['Name', 'Type', 'Units', 'Comments', 'bar'], prefix=('comment', 'description')), 3)
+        self.assertEqual(find_column_name(['Name', 'Type', 'Units', 'Description'], prefix=('comment', 'description')), 3)
         with self.assertRaises(IndexError) as e:
-            c = csv_unit_column(['Name', 'stuff', 'foo', 'Comments'])
+            c = find_column_name(['Name', 'stuff', 'foo', 'Comments'])
         self.assertEqual(e.exception.args[0], "No column matching 'unit' found!")
         with self.assertRaises(IndexError) as e:
-            c = csv_unit_column(['Name', 'unit', 'foo', 'bar'], comment=True)
+            c = find_column_name(['Name', 'unit', 'foo', 'bar'], prefix=('comment', 'description'))
         self.assertEqual(e.exception.args[0], "No column matching 'comment' found!")
 
+    def test_find_key_name(self):
+        """Test identification of unit column in YAML.
+        """
+        self.assertEqual(find_key_name({'unit': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}}), 'unit')
+        self.assertEqual(find_key_name({'Units': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}}), 'Units')
+        self.assertEqual(find_key_name({'comment': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': 'foo'}}, prefix=('comment', 'description')), 'comment')
+        self.assertEqual(find_key_name({'DESCRIPTION': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': 'foo'}}, prefix=('comment', 'description')), 'DESCRIPTION')
+        with self.assertRaises(KeyError) as e:
+            k = find_key_name({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None})
+        self.assertEqual(e.exception.args[0], "No key matching 'unit' found!")
+        with self.assertRaises(KeyError) as e:
+            k = find_key_name({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}, prefix=('comment', 'description'))
+        self.assertEqual(e.exception.args[0], "No key matching 'comment' found!")
+
     @patch('desiutil.annotate.log')
-    def test_csv_units(self, mock_log):
+    def test_load_csv_units(self, mock_log):
         """Test parsing of units in a CSV file.
         """
         c = """Name,Type,Unit,Comment
@@ -58,13 +72,13 @@ DEC,float32,deg,Declination"""
         unitsFile = os.path.join(self.tmp.name, 'test_one.csv')
         with open(unitsFile, 'w', newline='') as f:
             f.write(c)
-        units, comments = csv_units(unitsFile)
+        units, comments = load_csv_units(unitsFile)
         self.assertEqual(units['RA'], 'deg')
         self.assertEqual(units['COLUMN1'], '')
         self.assertEqual(comments['COLUMN1'], 'This is a comment.')
 
     @patch('desiutil.annotate.log')
-    def test_csv_units_no_comment(self, mock_log):
+    def test_load_csv_units_no_comment(self, mock_log):
         """Test parsing of units in a CSV file without comments.
         """
         c = """Name,Type,Unit
@@ -74,13 +88,13 @@ DEC,float32,deg"""
         unitsFile = os.path.join(self.tmp.name, 'test_two.csv')
         with open(unitsFile, 'w', newline='') as f:
             f.write(c)
-        units, comments = csv_units(unitsFile)
+        units, comments = load_csv_units(unitsFile)
         self.assertEqual(units['RA'], 'deg')
         self.assertEqual(units['COLUMN1'], '')
         self.assertFalse(bool(comments))
 
     @patch('desiutil.annotate.log')
-    def test_csv_units_no_units(self, mock_log):
+    def test_load_csv_units_no_units(self, mock_log):
         """Test parsing of units in a CSV file with bad units.
         """
         c = """Name,Type,Foobar
@@ -91,25 +105,11 @@ DEC,float32,deg"""
         with open(unitsFile, 'w', newline='') as f:
             f.write(c)
         with self.assertRaises(ValueError) as e:
-            units, comments = csv_units(unitsFile)
+            units, comments = load_csv_units(unitsFile)
         self.assertEqual(str(e.exception), f"{unitsFile} does not have a unit column!")
 
-    def test_yml_unit_key(self):
-        """Test identification of unit column in YAML.
-        """
-        self.assertEqual(yml_unit_key({'unit': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}}), 'unit')
-        self.assertEqual(yml_unit_key({'Units': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}}), 'Units')
-        self.assertEqual(yml_unit_key({'comment': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': 'foo'}}, comment=True), 'comment')
-        self.assertEqual(yml_unit_key({'DESCRIPTION': {'RA': 'deg', 'DEC': 'deg', 'COLUMN': 'foo'}}, comment=True), 'DESCRIPTION')
-        with self.assertRaises(KeyError) as e:
-            k = yml_unit_key({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None})
-        self.assertEqual(e.exception.args[0], "No key matching 'unit' found!")
-        with self.assertRaises(KeyError) as e:
-            k = yml_unit_key({'RA': 'deg', 'DEC': 'deg', 'COLUMN': None}, comment=True)
-        self.assertEqual(e.exception.args[0], "No key matching 'comment' found!")
-
     @patch('desiutil.annotate.log')
-    def test_yml_units(self, mock_log):
+    def test_load_yml_units(self, mock_log):
         """Test parsing of YAML input.
         """
         y = """unit:
@@ -120,14 +120,14 @@ DEC,float32,deg"""
         unitsFile = os.path.join(self.tmp.name, 'test_one.yml')
         with open(unitsFile, 'w', newline='') as f:
             f.write(y)
-        units, comments = yml_units(unitsFile)
+        units, comments = load_yml_units(unitsFile)
         self.assertEqual(units['RA'], 'deg')
         self.assertIsNone(units['COLUMN'])
         self.assertFalse(bool(comments))
         mock_log.warning.assert_not_called()
 
     @patch('desiutil.annotate.log')
-    def test_yml_units_backward(self, mock_log):
+    def test_load_yml_units_backward(self, mock_log):
         """Test parsing of older-style YAML input.
         """
         y = """RA: deg
@@ -137,14 +137,14 @@ COLUMN:
         unitsFile = os.path.join(self.tmp.name, 'test_one.yml')
         with open(unitsFile, 'w', newline='') as f:
             f.write(y)
-        units, comments = yml_units(unitsFile)
+        units, comments = load_yml_units(unitsFile)
         self.assertEqual(units['RA'], 'deg')
         self.assertIsNone(units['COLUMN'])
         self.assertFalse(bool(comments))
         mock_log.warning.assert_called_once_with(f'{unitsFile} does not have a unit column, assuming keys are columns!')
 
     @patch('desiutil.annotate.log')
-    def test_yml_units_comments(self, mock_log):
+    def test_load_yml_units_comments(self, mock_log):
         """Test parsing of YAML input with units and comments.
         """
         y = """unit:
@@ -159,7 +159,7 @@ Comments:
         unitsFile = os.path.join(self.tmp.name, 'test_one.yml')
         with open(unitsFile, 'w', newline='') as f:
             f.write(y)
-        units, comments = yml_units(unitsFile)
+        units, comments = load_yml_units(unitsFile)
         self.assertEqual(comments['RA'], 'deg')
         self.assertEqual(comments['COLUMN'], 'dimensionless')
         mock_log.warning.assert_not_called()
@@ -173,15 +173,17 @@ Comments:
         t['b'] = [2.14, 5.67]
         t['c'] = ['x', 'y']
         t['d'] = np.array([123, 456], dtype=np.uint64)
+        t['f'] = np.array([-15, 76], dtype=np.int16)
         u = {'a': 'm', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
         tt = annotate_table(t, u)
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
-        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
-                                        call("Not setting blank unit for column '%s'.", 'd'),
-                                        call("Column '%s' not present in table.", 'e')])
+                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                         call("Not setting blank unit for column '%s'.", 'c'),
+                                         call("Not setting blank unit for column '%s'.", 'd'),
+                                         call("Column '%s' not present in table.", 'e')])
+        mock_log.info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
 
     @patch('desiutil.annotate.log')
     def test_annotate_table_inplace(self, mock_log):
@@ -207,15 +209,17 @@ Comments:
         t['b'] = [2.14, 5.67]
         t['c'] = ['x', 'y']
         t['d'] = np.array([123, 456], dtype=np.uint64)
+        t['f'] = np.array([-15, 76], dtype=np.int16)
         u = {'a': 'm', 'b': 'deg', 'c': '', 'd': '', 'e': 'arcsec'}
         tt = annotate_table(t, u)
         self.assertEqual(tt['a'].unit, 'm')
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'm'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
-        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
-                                        call("Not setting blank unit for column '%s'.", 'd'),
-                                        call("Column '%s' not present in table.", 'e')])
+                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                         call("Not setting blank unit for column '%s'.", 'c'),
+                                         call("Not setting blank unit for column '%s'.", 'd'),
+                                         call("Column '%s' not present in table.", 'e')])
+        mock_log.info.assert_called_once_with("Column '%s' not found in units argument.", 'f')
 
     @patch('desiutil.annotate.log')
     def test_annotate_qtable_with_units_present(self, mock_log):
@@ -233,10 +237,11 @@ Comments:
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'cm'),
                                          call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'cm'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
-        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
-                                        call("Not setting blank unit for column '%s'.", 'd'),
-                                        call("Column '%s' not present in table.", 'e')])
+                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                         call("Not setting blank unit for column '%s'.", 'c'),
+                                         call("Not setting blank unit for column '%s'.", 'd'),
+                                         call("Column '%s' not present in table.", 'e')])
+        mock_log.info.assert_not_called()
 
     @patch('desiutil.annotate.log')
     def test_annotate_qtable_with_units_present_bad_conversion(self, mock_log):
@@ -254,8 +259,9 @@ Comments:
         self.assertEqual(tt['b'].unit, 'deg')
         mock_log.debug.assert_has_calls([call("t['%s'].unit = '%s'", 'a', 'A'),
                                          call("t.replace_column('%s', t['%s'].to('%s'))", 'a', 'a', 'A'),
-                                         call("t['%s'].unit = '%s'", 'b', 'deg')])
-        mock_log.info.assert_has_calls([call("Not setting blank unit for column '%s'.", 'c'),
-                                        call("Not setting blank unit for column '%s'.", 'd'),
-                                        call("Column '%s' not present in table.", 'e')])
+                                         call("t['%s'].unit = '%s'", 'b', 'deg'),
+                                         call("Not setting blank unit for column '%s'.", 'c'),
+                                         call("Not setting blank unit for column '%s'.", 'd'),
+                                         call("Column '%s' not present in table.", 'e')])
+        mock_log.info.assert_not_called()
         mock_log.error.assert_has_calls([call("Cannot add or replace unit '%s' to column '%s'!", 'A', 'a')])

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     healpy
     matplotlib
 scripts =
+    bin/annotate_fits
     bin/desi_api_file
     bin/desi_module_file
     bin/desi_update_version
@@ -48,6 +49,7 @@ scripts =
 
 # [options.entry_points]
 # console_scripts =
+#     annotate_fits = desiutil.annotate:main
 #     desiInstall = desiutil.install:main
 #     desi_api_file = desiutil.api:main
 #     desi_module_file = desiutil.modules:main


### PR DESCRIPTION
This PR addresses parts of #191, focussed on adding units to a `astropy.table.Table`.

Here's a simple test snippet:

```python
import os
import importlib.resources as ir
from astropy.table import Table
import desiutil.annotate as da
from desiutil.log import get_logger, DEBUG
da.log = get_logger(DEBUG)
csvFile = os.path.join(str(ir.files('desidatamodel')), 'data', 'column_descriptions.csv')
units, comments = da.csv_units(csvFile)
coadd = '/global/cfs/cdirs/desi/public/edr/spectro/redux/fuji/healpix/sv3/dark/99/9994/coadd-sv3-dark-9994.fits'
t = Table.read(coadd, hdu='FIBERMAP')
tt = da.annotate_table(t, units)  # tt is a copy of t; t is not supposed to be modified in this example.
# Try writing out tt.
```

TO DO:

- [x] Add additional unit tests.
- [ ] Operational testing; extending the snippet above.
