### PR TITLE
add support for removing dependencies

### DIFF
--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -131,13 +131,11 @@ def getdep(header, name):
     for i in range(100):
         namekey = 'DEPNAM{:02d}'.format(i)
         verkey = 'DEPVER{:02d}'.format(i)
-        if namekey in header:
-            if header[namekey] == name:
-                return header[verkey]
-        elif i == 0:
-            continue  # ok if DEPNAM00 is missing; continue to DEPNAME01
-        else:
-            raise KeyError('{} version not found'.format(name))
+        if namekey in header and header[namekey] == name:
+            return header[verkey]
+
+    # if we exited the loop, the name wasn't found in any DEPNAMnn
+    raise KeyError('{} version not found'.format(name))
 
 
 def hasdep(header, name):
@@ -173,12 +171,11 @@ def iterdep(header):
     for i in range(100):
         namekey = 'DEPNAM{:02d}'.format(i)
         verkey = 'DEPVER{:02d}'.format(i)
-        if namekey not in header and i == 0:
-            continue
         if namekey in header:
             yield (header[namekey], header[verkey])
         else:
-            return
+            continue  # ok if some DEPNAMnn are missing
+
     return
 
 
@@ -228,6 +225,36 @@ def mergedep(srchdr, dsthdr, conflict='src'):
         else:
             setdep(dsthdr, name, version)
 
+
+def removedep(header, name):
+    """
+    Removed dependency ``name`` from ``header``.
+
+    Parameters
+    ----------
+    header : dict-like
+        header object with DEPNAMnn/DEPVERnn keywords
+    name : str
+        name of dependency to remove
+
+    Notes
+    -----
+    Modifies header in-place
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not present in any of the DEPNAMnn keys
+    """
+    for i in range(100):
+        namekey = 'DEPNAM{:02d}'.format(i)
+        verkey = 'DEPVER{:02d}'.format(i)
+        if (namekey in header) and (header[namekey] == name):
+            del header[namekey]
+            del header[verkey]
+            break
+    else:
+        raise ValueError(f'{name} not found in header DEPNAMnn keywords')
 
 def add_dependencies(header, module_names=None, long_python=False,
                      envvar_names=None):
@@ -288,6 +315,28 @@ def add_dependencies(header, module_names=None, long_python=False,
         else:
             setdep(header, envvar, 'NOT_SET')
 
+
+def remove_dependencies(header):
+    """
+    Remove all DEPNAMnn/DEPVERnn dependencies from a header
+
+    Parameters
+    ----------
+    header : dict-like
+        header with DEPNAMnn/DEPVERnn keywords to remove
+
+    Notes
+    -----
+    Updates header in-place
+    """
+    # Assemble version keys first to avoid removing while iterating
+    keys = list()
+    for name, version in iterdep(header):
+        keys.append(name)
+
+    # now remove all keys
+    for name in keys:
+        removedep(header, name)
 
 class Dependencies(object):
     """Dictionary-like object to track dependencies.

--- a/py/desiutil/depend.py
+++ b/py/desiutil/depend.py
@@ -256,6 +256,7 @@ def removedep(header, name):
     else:
         raise ValueError(f'{name} not found in header DEPNAMnn keywords')
 
+
 def add_dependencies(header, module_names=None, long_python=False,
                      envvar_names=None):
     '''Adds ``DEPNAMnn``, ``DEPVERnn`` keywords to header for imported modules.
@@ -337,6 +338,7 @@ def remove_dependencies(header):
     # now remove all keys
     for name in keys:
         removedep(header, name)
+
 
 class Dependencies(object):
     """Dictionary-like object to track dependencies.


### PR DESCRIPTION
This PR updates `desiutil.depend` to add support for removing DEPNAMnn/DEPVERnn dependencies:
  * `removedep(header, name)`: remove a single dependency by name
  * `remove_dependencies(header)`: remove all dependencies

This also required some updates to `getdep` and `iterdep` to not trip on dependencies that had been removed, resulting in non-contiguous DEPNAMnn counting.

This will be used by desihub/desispec#2121 which needs to remove DEPNAM/DEPVER keywords from individual file inputs while stacking them so that they don't get incorrectly merged by `astropy.table.vstack` logic which doesn't know about DEPNAMnn/DEPVERnn pairs.