### PR TITLE
Add radec_to_desiname function

### DIFF
--- a/py/desiutil/names.py
+++ b/py/desiutil/names.py
@@ -10,6 +10,7 @@ or decoding those names
 """
 import numpy as np
 
+
 def radec_to_desiname(target_ra, target_dec):
     """Convert the right ascension and declination of a DESI target
     into the corresponding "DESI name" for reference in publications.

--- a/py/desiutil/names.py
+++ b/py/desiutil/names.py
@@ -11,6 +11,7 @@ or decoding those names
 import numpy as np
 
 
+
 def radec_to_desiname(target_ra, target_dec):
     """Convert the right ascension and declination of a DESI target
     into the corresponding "DESI name" for reference in publications.

--- a/py/desiutil/names.py
+++ b/py/desiutil/names.py
@@ -11,7 +11,6 @@ or decoding those names
 import numpy as np
 
 
-
 def radec_to_desiname(target_ra, target_dec):
     """Convert the right ascension and declination of a DESI target
     into the corresponding "DESI name" for reference in publications.

--- a/py/desiutil/names.py
+++ b/py/desiutil/names.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+============
+desiutil.names
+============
+
+This package contains functions for naming 'things' in DESI
+or decoding those names
+"""
+import numpy as np
+
+def radec_to_desiname(target_ra, target_dec):
+    """
+    Convert the right ascension and declination of a DESI target
+    into the corresponding "DESI name" for reference in publications.
+    Length of target_ra and target_dec must be the same if providing an
+    array or list.
+
+    Parameters
+    ----------
+    target_ra: array of :class:`float64`
+        Right ascension in degrees of target object(s). Can be float, double,
+         or array/list of floats or doubles
+    target_dec: array of :class:`float64`
+        Declination in degrees of target object(s). Can be float, double,
+         or array/list of floats or doubles
+
+    Returns
+    -------
+    desinames: array of :class:`string`
+        The DESI names referring to the input target RA and DEC's. Array is
+        the same length as the input arrays.
+
+    """
+    # Convert to numpy array in case inputs are scalars or lists
+    target_ra, target_dec = np.atleast_1d(target_ra), np.atleast_1d(target_dec)
+
+    # Number of decimal places in final naming convention
+    precision = 4
+
+    # Truncate decimals to the given precision
+    ratrunc = np.trunc((10 ** precision) * target_ra).astype(int).astype(str)
+    dectrunc = np.trunc((10 ** precision) * target_dec).astype(int).astype(str)
+
+    # Loop over input values and create DESINAME as: DESI JXXX.XXXX+/-YY.YYYY
+    # Here J refers to J2000, which isn't strictly correct but is the closest
+    #   IAU compliant term
+    desinames = []
+    for ra, dec in zip(ratrunc, dectrunc):
+        desiname = 'DESI J' + ra[:-precision].zfill(3) + '.' + ra[-precision:]
+        # Positive numbers need an explicit "+" while negative numbers
+        #   already have a "-".
+        # zfill works properly with '-' but counts it in number of characters
+        #   so need one more
+        if dec.startswith('-'):
+            desiname += dec[:-precision].zfill(3) + '.' + dec[-precision:]
+        else:
+            desiname += '+' + dec[:-precision].zfill(2) + '.' + dec[-precision:]
+        desinames.append(desiname)
+
+    return np.array(desinames)

--- a/py/desiutil/names.py
+++ b/py/desiutil/names.py
@@ -11,8 +11,7 @@ or decoding those names
 import numpy as np
 
 def radec_to_desiname(target_ra, target_dec):
-    """
-    Convert the right ascension and declination of a DESI target
+    """Convert the right ascension and declination of a DESI target
     into the corresponding "DESI name" for reference in publications.
     Length of target_ra and target_dec must be the same if providing an
     array or list.
@@ -28,7 +27,7 @@ def radec_to_desiname(target_ra, target_dec):
 
     Returns
     -------
-    desinames: array of :class:`string`
+    array of :class:`str`
         The DESI names referring to the input target RA and DEC's. Array is
         the same length as the input arrays.
 

--- a/py/desiutil/test/test_names.py
+++ b/py/desiutil/test/test_names.py
@@ -5,6 +5,7 @@
 import unittest
 import numpy as np
 
+
 class TestNames(unittest.TestCase):
     """Test desiutil.names
     """
@@ -22,9 +23,9 @@ class TestNames(unittest.TestCase):
         """
         from ..names import radec_to_desiname
         ras = [6.2457354547234, 23.914121939862518, 36.23454570972834,
-              235.25235223446, 99.9999999999999]
+               235.25235223446, 99.9999999999999]
         decs = [29.974787585945496, -42.945872347904356, -0.9968423456,
-               8.45677345352345, 89.234958294953]
+                8.45677345352345, 89.234958294953]
         correct_names = np.array(['DESI J006.2457+29.9747',
                                   'DESI J023.9141-42.9458',
                                   'DESI J036.2345-00.9968',
@@ -43,5 +44,3 @@ class TestNames(unittest.TestCase):
         outnames = radec_to_desiname(np.array(ras),
                                      np.array(decs))
         self.assertTrue(np.alltrue(outnames == correct_names))
-
-

--- a/py/desiutil/test/test_names.py
+++ b/py/desiutil/test/test_names.py
@@ -1,0 +1,47 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.names.
+"""
+import unittest
+import numpy as np
+
+class TestNames(unittest.TestCase):
+    """Test desiutil.names
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_radec_to_desiname(self):
+        """Test MaskedArrayWithLimits
+        """
+        from ..names import radec_to_desiname
+        ras = [6.2457354547234, 23.914121939862518, 36.23454570972834,
+              235.25235223446, 99.9999999999999]
+        decs = [29.974787585945496, -42.945872347904356, -0.9968423456,
+               8.45677345352345, 89.234958294953]
+        correct_names = np.array(['DESI J006.2457+29.9747',
+                                  'DESI J023.9141-42.9458',
+                                  'DESI J036.2345-00.9968',
+                                  'DESI J235.2523+08.4567',
+                                  'DESI J099.9999+89.2349'])
+        # Test scalar conversion
+        for ra, dec, correct_name in zip(ras, decs, correct_names):
+            outname = radec_to_desiname(ra, dec)
+            self.assertEqual(outname, correct_name)
+
+        # Test list conversion
+        outnames = radec_to_desiname(ras, decs)
+        self.assertTrue(np.alltrue(outnames == correct_names))
+
+        # Test array conversion
+        outnames = radec_to_desiname(np.array(ras),
+                                     np.array(decs))
+        self.assertTrue(np.alltrue(outnames == correct_names))
+
+


### PR DESCRIPTION
This pull request adds a new function, `desiutils.names.radec_to_desiname(target_ra, target_dec)` that provides the official DESI name for an object at a given sky location. It takes a scalar or array of DESI `TARGET_RA`'s and `TARGET_DEC`'s and returns the new `DESINAME`'s. 

The prescribed name is:  
<img width="1395" alt="image" src="https://github.com/desihub/desiutil/assets/8572603/63ce4794-024f-4928-a108-a0ac83bdceb7">

This is precise to 4 (truncated) decimal places in degrees and is therefore not unique for targets closer than ~0.36”. The J isn't strictly correct but specifying nothing is inferred as B1950, which is worse.

This naming convention does NOT guarantee uniqueness due to closely separated targets within DESI. However, increased precision in the name would be misleading because the fiber is ~1.5" in diameter and light from all sources in that vicinity is collected in an observation. 

Investigating the amount of naming collisions in the DESI Y1 Iron catalog:

- In the iron catalog (including negative targetids):
  - 868,688 desinames have multiple targetids out of 26,659,579. Percentage=3.26%
  - 6,799 targetids have multiple desinames out of 27,547,223. Percentage=0.02%
- In the iron catalog (excluding negative targetids):
  - 255,897 desinames have multiple targetids out of 22,979,345. Percentage=1.11%
  - 6,750 targetids have multiple desinames out of 23,229,349. Percentage=0.03%
- In iron cmx and excluding negative targetids:
  - 0 desinames have multiple targetids out of 5,000. Percentage=0.00%
  - 0 targetids have multiple desinames out of 5,000. Percentage=0.00%
- In iron sv1 and excluding negative targetids:
  - 533 desinames have multiple targetids out of 839,646. Percentage=0.06%
  - 25 targetids have multiple desinames out of 840,170. Percentage=0.00%
- In iron sv2 and excluding negative targetids:
  - 312 desinames have multiple targetids out of 139,313. Percentage=0.22%
  - 0 targetids have multiple desinames out of 139,625. Percentage=0.00%
- In iron sv3 and excluding negative targetids:
  - 77,747 desinames have multiple targetids out of 1,284,712. Percentage=6.05%
  - 0 targetids have multiple desinames out of 1,362,475. Percentage=0.00%
- In iron main and excluding negative targetids:
  - 161,267 desinames have multiple targetids out of 21,085,015. Percentage=0.76%
  - 0 targetids have multiple desinames out of 21,246,830. Percentage=0.00%


The vast majority of these naming "collisions" are due to "secondary" targets provided by the collaboration and not within the DESI main survey samples. Restricting to RELEASE >= 1000 removes these secondary targets:

- In Iron for all surveys (TARGETID > 0 AND RELEASE >= 1000):
  - 795 desinames have multiple targetids out of 21,159,555. Percentage=0.00%
  - 6,588 targetids have multiple desinames out of 21,153,765. Percentage=0.03%
- In Iron for cmx (TARGETID > 0 AND RELEASE >= 1000):
  - 0 desinames have multiple targetids out of 4,451. Percentage=0.00%
  - 0 targetids have multiple desinames out of 4,451. Percentage=0.00%
- In Iron for sv1 (TARGETID > 0 AND RELEASE >= 1000):
  - 6 desinames have multiple targetids out of 801,171. Percentage=0.00%
  - 25 targetids have multiple desinames out of 801,152. Percentage=0.00%
- In Iron for sv2 (TARGETID > 0 AND RELEASE >= 1000):
  - 1 desinames have multiple targetids out of 136,411. Percentage=0.00%
  - 0 targetids have multiple desinames out of 136,412. Percentage=0.00%
- In Iron for sv3 (TARGETID > 0 AND RELEASE >= 1000):
  - 77 desinames have multiple targetids out of 1,236,535. Percentage=0.01%
  - 0 targetids have multiple desinames out of 1,236,614. Percentage=0.00%
- In Iron for main (TARGETID > 0 AND RELEASE >= 1000):
  - 577 desinames have multiple targetids out of 19,419,142. Percentage=0.00%
  - 0 targetids have multiple desinames out of 19,419,722. Percentage=0.00% (edited) 

Because early SV1 data included proper motion corrections to their TARGET_RA and TARGET_DEC, a small number (6,588 targets out of 22 million) of TARGETID's have at least two DESINAME's depending on which version of TARGET_RA and TARGET_DEC is used for the objects. Our recommendation is to use the RA and DEC from the main survey without proper motion correction.