### PR TITLE
Add support for version string corner cases.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ['3.10']  # There are still issues with Numpy <1.23 and 3.11.
                 numpy-version: ['<1.23', '<1.24', '<2.0']
-                astropy-version: ['<5.1', '<6.0', '<7.0']
+                astropy-version: ['<6.0', '<6.1', '<7.0']
 
         steps:
             - name: Checkout code
@@ -89,7 +89,7 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip setuptools wheel Sphinx\<7 sphinx-rtd-theme
+              run: python -m pip install --upgrade pip setuptools wheel Sphinx sphinx-rtd-theme
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -15,8 +15,12 @@ Change Log
 ------------------
 
 * Check input bounds in :func:`~desiutil.names.radec_to_desiname` (PR `#207`_).
+* Allow for a greater diversity of version strings in
+  :func:`~desiutil.setup.get_version` (PR `#208`_, `#209`_).
 
 .. _`#207`: https://github.com/desihub/desiutil/pull/207
+.. _`#208`: https://github.com/desihub/desiutil/pull/208
+.. _`#209`: https://github.com/desihub/desiutil/pull/209
 
 3.4.2 (2023-11-29)
 ------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,6 +32,11 @@ need:
 * `matplotlib <https://matplotlib.org/>`_
 * `healpy <https://healpy.readthedocs.io/en/latest/>`_
 
+If you want to work with the dust utilities in :mod:`desiutil.dust`, you will
+need:
+
+* `SciPy <https://scipy.org>`
+
 Contents
 ========
 

--- a/py/desiutil/setup.py
+++ b/py/desiutil/setup.py
@@ -28,6 +28,12 @@ from .git import version as git_version
 from .modules import configure_module, process_module, default_module
 
 
+_match_version_line = re.compile(r"""__version__\s*=\s*  # opening part of the line, allow any amount of whitespace including none
+                                     (?P<oq>['"])        # match any opening quote and give it the label oq = opening quote
+                                     (?P<v>[^'"]+)       # any character not a quote, one or more times, label v = version
+                                     (?P=oq)             # match the same opening quote""", re.VERBOSE)
+
+
 class DesiAPI(Command):
     """Generate an api.rst file.
     """
@@ -295,9 +301,9 @@ def get_version(productname):
         update_version(productname)
     with open(version_file, "r") as f:
         for line in f.readlines():
-            mo = re.match("__version__ = ('|\")(.*)('|\")", line)
+            mo = _match_version_line.match(line)
             if mo:
-                ver = mo.group(2)
+                ver = mo.group('v')
     return ver
 
 

--- a/py/desiutil/test/test_setup.py
+++ b/py/desiutil/test/test_setup.py
@@ -154,6 +154,31 @@ setup(name="{0.fake_name}",
         v = get_version('desiutil')
         self.assertEqual(v, desiutil_version)
 
+    def test_get_version_corner_cases(self):
+        """Test parsing a _version.py file with 'by-hand' formatting.
+        """
+        corner_cases = ("__version__ = '1.2.3'\n",  # default format
+                        '__version__ = "1.2.3"\n',  # alternate quotes
+                        '__version__="1.2.3"\n',  # no whitespace
+                        '__version__\t=\t"1.2.3"\n',  # alternate whitespace
+                        "__version__= \t\t '1.2.3'\n",  # really alternate whitespace
+                        """__version__ = "1.2.3'\n""")  # mismatched quotes, should fail.
+        p = os.path.join(self.setup_dir, self.fake_name)
+        os.makedirs(p)
+        os.chdir(self.setup_dir)
+        version_file = os.path.join(p, '_version.py')
+        for case in corner_cases:
+            with open(version_file, 'w') as v:
+                v.write(case)
+            version = get_version(self.fake_name)
+            if case == """__version__ = "1.2.3'\n""":
+                self.assertEqual(version, 'unknown')
+            else:
+                self.assertEqual(version, '1.2.3')
+        os.remove(os.path.join(p, '_version.py'))
+        os.rmdir(p)
+        os.chdir(self.original_dir)
+
     def test_update_version(self):
         """Test creating and updating a _version.py file.
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     requests
     pyyaml
     numpy<2.0
-    scipy
     astropy>=5.0
     healpy
     matplotlib
@@ -59,7 +58,9 @@ scripts =
 [options.extras_require]
 test =
     pytest
+    scipy
 coverage =
+    scipy
     pytest-cov
     coveralls
 doc =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     requests
     pyyaml
     numpy<2.0
+    scipy
     astropy>=5.0
     healpy
     matplotlib


### PR DESCRIPTION
This PR allows a wide variety of valid version strings to be parsed by `desiutil.setup.get_version()`.

While developing this, it was discovered that `desiutil.dust.ext_fitzpatrick()` requires `scipy`, but this requirement had never been explicitly listed. It appears that previously, one or more of astropy, healpy or matplotlib would bring in a dependency on scipy, but more recent versions do not have that dependency, so scipy has to be installed explicitly.