### PR TITLE
Support for mask bits in Numpy 2

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,22 +11,21 @@ Change Log
 * Remove deprecated module :mod:`desiutil.census`.
 * Remove deprecated top-level ``setup.py``.
 
-3.5.1 (unreleased)
+3.5.1 (2025-04-25)
 ------------------
 
-* No changes yet.
+* Fix NumPy 2 support for :class:`desiutil.bitmask._MaskBit`;
+  clean up package metadata to avoid warnings while building PyPI packages (PR `#219`_).
+
+.. _`#219`: https://github.com/desihub/desiutil/pull/219
 
 3.5.0 (2025-01-13)
 ------------------
 
-Multiple updates bundled in PR `#212`_:
-
-* Fix bug in :func:`~desiutil.names.radec_to_desiname` for values very close to zero.
-* Don't issue warnings in :func:`~desiutil.annotate.annotate_fits` if the units
-  are not actually changing.
-* General package clean-up in preparation for deployment to PyPI_, including
-  removing ``desiutil.setup.DesiTest``.  Impacted packages should remove that
-  import from their ``setup.py`` and use ``pytest`` instead of ``python setup.py test``.
+* Fix bug in :func:`~desiutil.names.radec_to_desiname` for values very close to zero;
+  don't issue warnings in :func:`~desiutil.annotate.annotate_fits` if the units
+  are not actually changing; general package clean-up in preparation for
+  deployment to PyPI_ (PR `#212`_).
 
 .. _PyPI: https://pypi.org
 .. _`#212`: https://github.com/desihub/desiutil/pull/212

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -22,10 +22,14 @@ Change Log
 3.5.0 (2025-01-13)
 ------------------
 
-* Fix bug in :func:`~desiutil.names.radec_to_desiname` for values very close to zero;
-  don't issue warnings in :func:`~desiutil.annotate.annotate_fits` if the units
-  are not actually changing; general package clean-up in preparation for
-  deployment to PyPI_ (PR `#212`_).
+Multiple updates bundled in PR `#212`_:
+
+* Fix bug in :func:`~desiutil.names.radec_to_desiname` for values very close to zero.
+* Don't issue warnings in :func:`~desiutil.annotate.annotate_fits` if the units
+  are not actually changing.
+* General package clean-up in preparation for deployment to PyPI_, including
+  removing ``desiutil.setup.DesiTest``.  Impacted packages should remove that
+  import from their ``setup.py`` and use ``pytest`` instead of ``python setup.py test``.
 
 .. _PyPI: https://pypi.org
 .. _`#212`: https://github.com/desihub/desiutil/pull/212

--- a/py/desiutil/bitmask.py
+++ b/py/desiutil/bitmask.py
@@ -114,13 +114,6 @@ class _MaskBit(int):
             else:
                 args.append(input_)
         #
-        # This is boilerplate designed to capture ``out`` keywords.
-        #
-        # try:
-        #     outputs = kwargs['out']
-        # except KeyError:
-        #     outputs = (None,) * ufunc.nout
-        #
         # Identify another argument that we can pass the computation to.
         #
         sup = None
@@ -132,19 +125,6 @@ class _MaskBit(int):
             return NotImplemented
 
         return sup.__array_ufunc__(ufunc, method, *args, **kwargs)
-        # results = sup.__array_ufunc__(ufunc, method, *args, **kwargs)
-        # if results is NotImplemented:
-        #     return NotImplemented
-        #
-        # Deal with multiple outputs.
-        #
-        # if ufunc.nout == 1:
-        #     results = (results,)
-
-        # results = tuple((np.asarray(result) if output is None else output)
-        #                 for result, output in zip(results, outputs))
-
-        # return results[0] if len(results) == 1 else results
 
 
 #  Class to provide mask bit utility functions

--- a/py/desiutil/bitmask.py
+++ b/py/desiutil/bitmask.py
@@ -97,8 +97,7 @@ class _MaskBit(int):
         return ('{0.name:16s} bit {0.bitnum} mask 0x{0.mask:X} - ' +
                 '{0.comment}').format(self)
 
-    # def __repr__(self):
-    #     return "_MaskBit(name='{0.name}', bitnum={0.bitnum:d}, comment='{0.comment}')".format(self)
+    # We do not define __repr__(self) since the superclass has an arguably more useful __repr__().
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """This function makes :class:`~desiutil.bitmask._MaskBit` objects "NumPy-aware",

--- a/py/desiutil/bitmask.py
+++ b/py/desiutil/bitmask.py
@@ -101,8 +101,38 @@ class _MaskBit(int):
     #     return "_MaskBit(name='{0.name}', bitnum={0.bitnum:d}, comment='{0.comment}')".format(self)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        """When working with Numpy functions and objects, replace the input
-        ``_MaskBit`` object with its ``.mask`` attribute.
+        """This function makes :class:`~desiutil.bitmask._MaskBit` objects "NumPy-aware",
+        so that they can be handled by NumPy `ufunc <https://numpy.org/doc/stable/glossary.html#term-ufunc>`_ methods.
+
+        Parameters
+        ----------
+        ufunc : :class:`numpy.ufunc`
+            The NumPy function, *e.g.* :func:`~numpy.bitwise_or`.
+        method : :class:`str`
+            How `ufunc` was called. This is meant to be passed to another operand.
+        inputs : :class:`list`
+            The positional arguments.
+        kwargs : :class:`dict`
+            The keyword arguments.
+
+        Returns
+        -------
+        array-like
+            This function passes the actual computation to another entry in `inputs`.
+
+        Notes
+        -----
+        * In NumPy 1.x, subclasses of :class:`int` could be used exactly as if the
+          object was a plain Python :class:`int`.
+        * In Numpy 2.x, that is no longer the case, so we must explicitly use the
+          array API to tell NumPy how to handle the subclass.
+        * The solution is to modify the inputs so that a :class:`~desiutil.bitmask._MaskBit`
+          object is replaced by its ``.mask`` attribute, which is a plain Python :class:`int`.
+        * See GitHub issue `#218`_ for examples and discussion.
+        * This method is based on `this discussion`_.
+
+        .. _`#218`: https://github.com/desihub/desiutil/issues/218
+        .. _`this discussion`: https://numpy.org/doc/stable/user/basics.subclassing.html#array-ufunc-for-ufuncs
         """
         #
         # Filter inputs and replace any _MaskBit with a Python int.

--- a/py/desiutil/bitmask.py
+++ b/py/desiutil/bitmask.py
@@ -116,10 +116,10 @@ class _MaskBit(int):
         #
         # This is boilerplate designed to capture ``out`` keywords.
         #
-        try:
-            outputs = kwargs['out']
-        except KeyError:
-            outputs = (None,) * ufunc.nout
+        # try:
+        #     outputs = kwargs['out']
+        # except KeyError:
+        #     outputs = (None,) * ufunc.nout
         #
         # Identify another argument that we can pass the computation to.
         #
@@ -131,19 +131,20 @@ class _MaskBit(int):
         if sup is None:
             return NotImplemented
 
-        results = sup.__array_ufunc__(ufunc, method, *args, **kwargs)
-        if results is NotImplemented:
-            return NotImplemented
+        return sup.__array_ufunc__(ufunc, method, *args, **kwargs)
+        # results = sup.__array_ufunc__(ufunc, method, *args, **kwargs)
+        # if results is NotImplemented:
+        #     return NotImplemented
         #
         # Deal with multiple outputs.
         #
-        if ufunc.nout == 1:
-            results = (results,)
+        # if ufunc.nout == 1:
+        #     results = (results,)
 
-        results = tuple((np.asarray(result) if output is None else output)
-                        for result, output in zip(results, outputs))
+        # results = tuple((np.asarray(result) if output is None else output)
+        #                 for result, output in zip(results, outputs))
 
-        return results[0] if len(results) == 1 else results
+        # return results[0] if len(results) == 1 else results
 
 
 #  Class to provide mask bit utility functions

--- a/py/desiutil/bitmask.py
+++ b/py/desiutil/bitmask.py
@@ -100,7 +100,7 @@ class _MaskBit(int):
     # def __repr__(self):
     #     return "_MaskBit(name='{0.name}', bitnum={0.bitnum:d}, comment='{0.comment}')".format(self)
 
-    def __array_ufunc__(self, ufunc, method, *inputs, out=None, **kwargs):
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """When working with Numpy functions and objects, replace the input
         ``_MaskBit`` object with its ``.mask`` attribute.
         """
@@ -113,22 +113,13 @@ class _MaskBit(int):
                 args.append(input_.mask)
             else:
                 args.append(input_)
-
         #
         # This is boilerplate designed to capture ``out`` keywords.
         #
-        outputs = out
-        if outputs:
-            out_args = []
-            for output in outputs:
-                if isinstance(output, _MaskBit):
-                    out_args.append(output.view(np.ndarray))
-                else:
-                    out_args.append(output)
-            kwargs['out'] = tuple(out_args)
-        else:
+        try:
+            outputs = kwargs['out']
+        except KeyError:
             outputs = (None,) * ufunc.nout
-
         #
         # Identify another argument that we can pass the computation to.
         #

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -193,14 +193,28 @@ class TestBitMask(unittest.TestCase):
         for array in (signed_array_16, signed_array_32, signed_array_64,
                       unsigned_array_16, unsigned_array_32, unsigned_array_64):
             new_array = array.copy()
+            # Test a simple bitwise OR.
             new_array |= self.ccdmask.COSMIC
             new_array |= self.ccdmask.HOT
             self.assertTrue((new_array == (array + 18)).all())
+            # Test unaugmented operator
+            result = new_array & self.ccdmask.COSMIC
+            self.assertTrue((result != 0).all())
+            # Test an explicit function call, and ensure the order of the arguments doesn't matter.
             self.assertTrue((np.bitwise_and(new_array, self.ccdmask.HOT) != 0).all())
             self.assertTrue((np.bitwise_and(self.ccdmask.HOT, new_array) != 0).all())
+            # Test a ufunc call with an out keyword.
             out_array = array.copy()
             np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array)
             self.assertTrue((out_array == (array + 19)).all())
+            # Test other combinations of mask bits.
+            new_array = array.copy()
+            new_array |= self.ccdmask.mask('DEAD|SATURATED')
+            self.assertTrue((new_array == (array + 12)).all())
+            new_array = array.copy()
+            new_array |= (self.ccdmask.DEAD | self.ccdmask.SATURATED)
+            self.assertTrue((new_array == (array + 12)).all())
+            # Test expected behavior when neither argument is a Numpy object.
             with self.assertRaises(TypeError):
                 result = np.bitwise_or(0, self.ccdmask.COSMIC)
             with self.assertRaises(TypeError):

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -200,4 +200,4 @@ class TestBitMask(unittest.TestCase):
             out_array = array.copy()
             # self.assertTrue((np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array) == array).all())
             np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array)
-            self.assertTrue((out_array == array).all())
+            self.assertTrue((out_array == (array + 19)).all())

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -197,5 +197,7 @@ class TestBitMask(unittest.TestCase):
             new_array |= self.ccdmask.HOT
             self.assertTrue((new_array == (array + 18)).all())
             self.assertTrue((np.bitwise_and(new_array, self.ccdmask.HOT) != 0).all())
-            out_array=array.copy()
-            self.assertTrue((np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array) == array).all())
+            out_array = array.copy()
+            # self.assertTrue((np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array) == array).all())
+            np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array)
+            self.assertTrue((out_array == array).all())

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 """Test desiutil.bitmask.
 """
-import sys
 import unittest
 from ..bitmask import BitMask, _MaskBit
 import yaml
@@ -181,3 +180,19 @@ class TestBitMask(unittest.TestCase):
         for i, name in enumerate(self.ccdmask.names()):
             self.assertEqual(str(self.ccdmask[name]), bit_str[i])
             self.assertEqual(repr(self.ccdmask[name]), bit_repr[i])
+
+    def test_numpy_compat(self):
+        """Test compatibility with Numpy 1 and Numpy 2.
+        """
+        signed_array_16 = np.zeros((10,), dtype=np.int16)
+        signed_array_32 = np.zeros((10,), dtype=np.int32)
+        signed_array_64 = np.zeros((10,), dtype=np.int64)
+        unsigned_array_16 = np.zeros((10,), dtype=np.uint16)
+        unsigned_array_32 = np.zeros((10,), dtype=np.uint32)
+        unsigned_array_64 = np.zeros((10,), dtype=np.uint64)
+        for array in (signed_array_16, signed_array_32, signed_array_64,
+                      unsigned_array_16, unsigned_array_32, unsigned_array_64):
+            new_array = array.copy()
+            new_array |= self.ccdmask.COSMIC
+            new_array &= self.ccdmask.HOT
+            self.assertTrue((new_array == (array + 18)).all())

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -219,3 +219,8 @@ class TestBitMask(unittest.TestCase):
                 result = np.bitwise_or(0, self.ccdmask.COSMIC)
             with self.assertRaises(TypeError):
                 result = np.bitwise_or(self.ccdmask.COSMIC, 0)
+
+    def test_int_behavior(self):
+        """Test behavior of _MaskBit when explicitly casting to int.
+        """
+        self.assertEqual(self.ccdmask.HOT.mask, int(self.ccdmask.HOT))

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -200,5 +200,7 @@ class TestBitMask(unittest.TestCase):
             out_array = array.copy()
             np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array)
             self.assertTrue((out_array == (array + 19)).all())
-            result = np.bitwise_or(0, self.ccdmask.COSMIC)
-            self.assertIs(result, NotImplemented)
+            with self.assertRaises(TypeError):
+                result = np.bitwise_or(0, self.ccdmask.COSMIC)
+            with self.assertRaises(TypeError):
+                result = np.bitwise_or(self.ccdmask.COSMIC, 0)

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -198,6 +198,7 @@ class TestBitMask(unittest.TestCase):
             self.assertTrue((new_array == (array + 18)).all())
             self.assertTrue((np.bitwise_and(new_array, self.ccdmask.HOT) != 0).all())
             out_array = array.copy()
-            # self.assertTrue((np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array) == array).all())
             np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array)
             self.assertTrue((out_array == (array + 19)).all())
+            result = np.bitwise_or(0, self.ccdmask.COSMIC)
+            self.assertIs(result, NotImplemented)

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -197,6 +197,7 @@ class TestBitMask(unittest.TestCase):
             new_array |= self.ccdmask.HOT
             self.assertTrue((new_array == (array + 18)).all())
             self.assertTrue((np.bitwise_and(new_array, self.ccdmask.HOT) != 0).all())
+            self.assertTrue((np.bitwise_and(self.ccdmask.HOT, new_array) != 0).all())
             out_array = array.copy()
             np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array)
             self.assertTrue((out_array == (array + 19)).all())

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -197,3 +197,5 @@ class TestBitMask(unittest.TestCase):
             new_array |= self.ccdmask.HOT
             self.assertTrue((new_array == (array + 18)).all())
             self.assertTrue((np.bitwise_and(new_array, self.ccdmask.HOT) != 0).all())
+            out_array=array.copy()
+            self.assertTrue((np.bitwise_xor(new_array, self.ccdmask.BAD, out=out_array) == array).all())

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -194,5 +194,6 @@ class TestBitMask(unittest.TestCase):
                       unsigned_array_16, unsigned_array_32, unsigned_array_64):
             new_array = array.copy()
             new_array |= self.ccdmask.COSMIC
-            new_array &= self.ccdmask.HOT
+            new_array |= self.ccdmask.HOT
             self.assertTrue((new_array == (array + 18)).all())
+            self.assertTrue((np.bitwise_and(new_array, self.ccdmask.HOT) != 0).all())

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,14 +25,15 @@ classifiers =
 zip_safe = True
 package_dir =
     =py
-packages = find:
+# find_namespace avoids a warning about data directories when building packages.
+packages = find_namespace:
 include_package_data = True
 python_requires = >=3.10
 # setup_requires = setuptools_scm
 install_requires =
     requests
     pyyaml
-    astropy<7
+    astropy
 scripts =
     bin/annotate_fits
     bin/desi_api_file

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = desiutil
 version = attr: desiutil.__version__
 author = DESI Collaboration
 author_email = desi-data@desi.lbl.gov
-license = BSD 3-Clause License
+license = BSD-3-Clause
 license_files = LICENSE.rst
 url = https://github.com/desihub/desiutil
 description = DESI utilities package
@@ -15,7 +15,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Science/Research
-    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Topic :: Scientific/Engineering :: Astronomy


### PR DESCRIPTION
This PR fixes #218.

This should be tested with other packages such as desispec and desitarget before merging.