### PR TITLE
Support for NumPy scalars

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,12 @@ Change Log
 3.5.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix operations involving :class:`desiutil.bitmask._MaskBit` and `NumPy scalars`_;
+  remove long-deprecated import of ``setuptools.sandbox`` and associated test code
+  (PR `#221`_).
+
+.. _`#221`: https://github.com/desihub/desiutil/pull/221
+.. _`NumPy scalars`: https://numpy.org/doc/stable/reference/arrays.scalars.html
 
 3.5.1 (2025-04-25)
 ------------------

--- a/py/desiutil/bitmask.py
+++ b/py/desiutil/bitmask.py
@@ -135,11 +135,14 @@ class _MaskBit(int):
         """
         #
         # Filter inputs and replace any _MaskBit with a Python int.
+        # np.generic is the superclass of all NumPy scalars.
         #
         args = []
         for input_ in inputs:
             if isinstance(input_, _MaskBit):
                 args.append(input_.mask)
+            elif isinstance(input_, np.generic):
+                args.append(np.asarray(input_))
             else:
                 args.append(input_)
         #

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -224,3 +224,15 @@ class TestBitMask(unittest.TestCase):
         """Test behavior of _MaskBit when explicitly casting to int.
         """
         self.assertEqual(self.ccdmask.HOT.mask, int(self.ccdmask.HOT))
+
+    def test_numpy_scalar(self):
+        """Test behavior of _MaskBit when other operand is a numpy scalar.
+        """
+        for b in (False, True):
+            for t in (np.bool_, np.int16, np.int32, np.int64, np.uint16, np.uint32, np.uint64):
+                result = t(b) * self.ccdmask.COSMIC
+                self.assertEqual(result, int(b) * self.ccdmask.COSMIC)
+                if t is np.bool_:
+                    self.assertIs(type(result), np.int64)
+                else:
+                    self.assertIs(type(result), t)

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -6,6 +6,7 @@ import unittest
 from ..bitmask import BitMask, _MaskBit
 import yaml
 import numpy as np
+import warnings
 
 _bitdefyaml = """\
 ccdmask:
@@ -234,5 +235,10 @@ class TestBitMask(unittest.TestCase):
                 self.assertEqual(result, int(b) * self.ccdmask.COSMIC)
                 if t is np.bool_:
                     self.assertIs(type(result), np.int64)
+                elif np.__version__[0] == '1':
+                    if t is np.uint64:
+                        self.assertIs(type(result), np.float64)
+                    else:
+                        self.assertIs(type(result), np.int64)
                 else:
                     self.assertIs(type(result), t)

--- a/py/desiutil/test/test_bitmask.py
+++ b/py/desiutil/test/test_bitmask.py
@@ -6,7 +6,7 @@ import unittest
 from ..bitmask import BitMask, _MaskBit
 import yaml
 import numpy as np
-import warnings
+
 
 _bitdefyaml = """\
 ccdmask:

--- a/py/desiutil/test/test_setup.py
+++ b/py/desiutil/test/test_setup.py
@@ -9,7 +9,6 @@ import unittest
 from unittest.mock import call, patch
 from tempfile import mkdtemp
 from distutils.log import INFO, WARN
-from setuptools import sandbox
 from ..setup import find_version_directory, get_version, update_version
 from .. import __version__ as desiutil_version
 
@@ -22,9 +21,6 @@ class TestSetup(unittest.TestCase):
     def setUpClass(cls):
         cls.fake_name = 'frobulate'
         cls.original_dir = os.getcwd()
-        # Workaround for https://github.com/astropy/astropy-helpers/issues/124
-        if hasattr(sandbox, 'hide_setuptools'):
-            sandbox.hide_setuptools = lambda: None
 
     @classmethod
     def tearDownClass(cls):
@@ -44,17 +40,6 @@ class TestSetup(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.original_dir)
         shutil.rmtree(self.setup_dir, ignore_errors=True)
-
-    def run_setup(self, *args, **kwargs):
-        """In Python 3, on MacOS X, the import cache has to be invalidated
-        otherwise new extensions built with ``run_setup`` do not always get
-        picked up.
-        """
-        try:
-            return sandbox.run_setup(*args, **kwargs)
-        finally:
-            import importlib
-            importlib.invalidate_caches()
 
     def test_version(self):
         """Test python setup.py version.

--- a/py/desiutil/test/test_setup.py
+++ b/py/desiutil/test/test_setup.py
@@ -41,59 +41,6 @@ class TestSetup(unittest.TestCase):
         os.chdir(self.original_dir)
         shutil.rmtree(self.setup_dir, ignore_errors=True)
 
-    def test_version(self):
-        """Test python setup.py version.
-        """
-        path_index = int(sys.path[0] == '')
-        sys.path.insert(path_index, os.path.abspath('./py'))
-        package_dir = os.path.join(self.setup_dir, self.fake_name)
-        os.mkdir(package_dir)
-        os.mkdir(os.path.join(package_dir, self.fake_name))
-        os.mkdir(os.path.join(package_dir, '.git'))
-        setup = """#!/usr/bin/env python
-from setuptools import setup
-from desiutil.setup import DesiModule, DesiVersion, get_version
-CMDCLASS = {{'version': DesiVersion}}
-VERSION = get_version("{0.fake_name}")
-setup(name="{0.fake_name}",
-    version=VERSION,
-    packages=["{0.fake_name}"],
-    cmdclass=CMDCLASS,
-    zip_safe=False)
-""".format(self)
-        with open(os.path.join(package_dir, 'setup.py'), 'w') as s:
-            s.write(setup)
-        init = """from ._version import __version__
-"""
-        with open(os.path.join(package_dir, self.fake_name,
-                               '__init__.py'), 'w') as i:
-            i.write(init)
-        os.chdir(package_dir)
-        v_file = os.path.join(package_dir, self.fake_name, '_version.py')
-        with patch('distutils.cmd.Command.announce') as mock_announce:
-            with patch('distutils.log.info') as mock_info:
-                self.run_setup('setup.py', ['version'])
-                self.assertTrue(os.path.exists(v_file))
-                self.assertListEqual(mock_announce.mock_calls,
-                                     [call('WARNING: This functionality is deprecated and will be removed from a future version of desiutil.', level=WARN),
-                                      call('WARNING: Use the command-line script desi_update_version instead.', level=WARN),
-                                      call('Version is now 0.0.1.dev0.', level=INFO)])
-                # self.assertListEqual(mock_info.mock_calls, [call('running %s', 'version')])
-        with patch('distutils.cmd.Command.announce') as mock_announce:
-            with patch('distutils.log.info') as mock_info:
-                self.run_setup('setup.py', ['version', '--tag', '1.2.3'])
-                with open(v_file) as v:
-                    data = v.read()
-                self.assertEqual(data, "__version__ = '1.2.3'\n")
-                self.assertListEqual(mock_announce.mock_calls,
-                                     [call('WARNING: This functionality is deprecated and will be removed from a future version of desiutil.', level=WARN),
-                                      call('WARNING: Use the command-line script desi_update_version instead.', level=WARN),
-                                      call('Version is now 1.2.3.', level=INFO)])
-                # self.assertListEqual(mock_info.mock_calls, [call('running %s', 'version')])
-
-        os.chdir(self.original_dir)
-        del sys.path[path_index]
-
     def test_find_version_directory(self):
         """Test the search for a _version.py file.
         """


### PR DESCRIPTION
This PR fixes #220.

In #219, I think there was a miscommunication:

> I confirm that this fixes the desispec mask-related test failures when running with numpy 2.x, and also works with numpy 1.x.

I assumed that meant that all tests with desitarget, desispec, redrock, and any other package in the nightly desitest suite were succeeding. But that doesn't seem to be consistent with #220. But maybe that meant *only* desispec? Please clarify.

In any case, let's make sure that *every* package is happy with these changes before merging.