### PR TITLE
Remove unneeded requirements

### DIFF
--- a/doc/rtd-requirements.txt
+++ b/doc/rtd-requirements.txt
@@ -1,4 +1,1 @@
-setuptools>60
-Sphinx>6,<7
 sphinx-rtd-theme>1
-urllib3<2


### PR DESCRIPTION
This is a very minor PR that removes references to `urllib3<2` from `doc/rtd-requirements.txt`. `urllib3<2` is being flagged as a security vulnerability by GitHub, even though it is not part of active user code.