### PR TITLE
add desiutil.healpix

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -32,6 +32,9 @@ desiutil API
 .. automodule:: desiutil.git
     :members:
 
+.. automodule:: desiutil.healpix
+    :members:
+
 .. automodule:: desiutil.iers
     :members:
 

--- a/py/desiutil/healpix.py
+++ b/py/desiutil/healpix.py
@@ -1,0 +1,188 @@
+"""
+================
+desiutil.healpix
+================
+
+Utilities for working with healpix tiling, including unique pixel
+encoding both nside,healpix into a single integer:
+
+    uniqpix = healpix + 4*nside**2
+
+See Section 3.2 of the `HEALpix Primer <https://healpix.sourceforge.io/pdf/intro.pdf>`_
+for further information about the unique pixel identifier scheme.
+
+DESI uses nested healpixels (not ring), with coordinates ra,dec in degrees.
+"""
+
+import os, sys
+import numpy as np
+import healpy
+
+def radec2hpix(nside, ra, dec):
+    """Convert nside, ra, dec in degrees to nested healpixel number
+
+    Args:
+        nside (int or array of int): healpixel nside (power of 2)
+        ra (float or array of float): Right Ascension (degrees)
+        dec (float or array of float): Declination (degrees)
+
+    Returns:
+        healpixel number(s)
+    """
+    return healpy.ang2pix(nside, ra, dec, lonlat=True, nest=True)
+
+def radec2upix(nside, ra, dec):
+    """Convert nside, ra, dec in degrees to nested unique pixel number
+
+    Args:
+        nside (int or array of int): healpixel nside (power of 2)
+        ra (float or array of float): Right Ascension (degrees)
+        dec (float or array of float): Declination (degrees)
+
+    Returns:
+        uniquepixel(s)
+    """
+    hpix = radec2hpix(nside, ra, dec)
+    return hpix2upix(nside, hpix)
+
+def hpix2upix(nside, hpix):
+    """Convert nside,healpix into unique pixel
+
+    Args:
+        nside (int or array of int): healpixel nside (power of 2)
+        hpix (int or array of int): healpixel number
+
+    Returns:
+        uniquepixel(s)
+    """
+    return hpix + 4*nside**2
+
+def upix2hpix(upix):
+    """Decode unique pixel upix into nside and healpixel
+
+    Args:
+        upix (int or array of int): encoded unique pixel(s)
+
+    Returns (nsides, healpixels)
+    """
+    nside = 2**( (np.log2(upix//4)/2).astype(int) )
+    hpix = upix - 4 * nside**2
+
+    return nside, hpix
+
+def partition_radec(ra, dec, nmax):
+    """Partition `ra,dec` arrays into nested unique pixels with at most `nmax` elements each
+
+    Args:
+        ra (array of float): Right Ascension (degrees)
+        dec (array of float): Declination (degrees)
+        nmax (int): maximum entries per unique pixel
+
+    Returns:
+        uniqpixels (array of same length as `ra` and `dec`)
+
+    Partitions ra,dec elements into healpix, recursively splitting
+    healpixels with more than nmax elements into smaller healpix at
+    larger nside, until all healpix have nmax or fewer elements.
+    Returns corresponding (nside,healpix) encoded into unique pixels.
+    """
+
+    #- First calculate upix at nside=1
+    order = 0
+    nside = 2**order
+    hpix = radec2hpix(nside, ra, dec)
+    upix = hpix2upix(nside, hpix)
+
+    #- then iteratively split large pixels into higher nside (smaller pixels)
+    #- until all pixels have fewer than nmax entries.
+    for order in range(1,12):
+        upix_values, target_per_upix = np.unique(upix, return_counts=True)
+        too_many = (target_per_upix > nmax)
+        if np.any(too_many):
+            ii = np.isin(upix, upix_values[too_many])
+            nside = 2**order
+            print(f'{np.sum(too_many)}/{len(too_many)} upix with {np.sum(ii)} targets are too dense; splitting those from nside={nside//2} to {nside}')
+            hpix = radec2hpix(nside, ra[ii], dec[ii])
+            upix[ii] = hpix2upix(nside, hpix)
+        else:
+            break
+
+    return upix
+
+def is_in_sorted_array(a, b):
+    """
+    Return bool array for if elements of array `a` are in sorted array `b`
+
+    Note: for efficiency, this does not check that `b` is sorted
+    """
+    # Find the insertion points for elements of a in b
+    a = np.asarray(a)
+    b = np.asarray(b)
+    indices = np.searchsorted(b, a)
+
+    # Check if the elements at these indices match the elements of a
+    # while avoiding overflow
+    return (indices < len(b)) & (b[indices%len(b)] == a)
+
+def find_upix(ra, dec, available_upix):
+    """find which nested unique pixels cover input ra,dec values
+
+    Args:
+        ra (array of float): Right Ascension (degrees)
+        dec (array of float): Declination (degrees)
+        available_upix (int array): unique pixels
+
+    Returns:
+        uniqpix array for each ra,dec element. 0 if not in available_upix.
+
+    Input ra,dec can map to multiple healpix at different nside, and thus
+    multiple unique pixel values. Given array of which `available_upix` values
+    are actually used, this function finds which `uniqpix` values to use for
+    each ra,dec.
+    """
+
+    #- Handle scalar or vector input
+    scalar_input = np.isscalar(ra)
+    ra = np.atleast_1d(ra)
+    dec = np.atleast_1d(dec)
+    assert len(ra) == len(dec)
+
+    #- Confirm that available_upix is sorted and unique
+    if not np.all(np.diff(available_upix) > 0):
+        available_upix = np.unique(available_upix)
+
+    #- Output array to fill
+    result_upix = np.zeros(len(ra), dtype=int)
+    not_found = np.ones(len(ra), dtype=bool)
+
+    #- Loop over possible nsides, testing if ra,dec values are in
+    #- available_upix at that nside.  Do this in descending order
+    #- so that radec2hpix is only calculated once (slow).
+
+    available_nside = np.unique( upix2hpix(available_upix)[0] )
+    assert available_nside[0] >= 1
+    nside = available_nside[-1]  # max nside
+    hpix = radec2hpix(nside, ra, dec)
+    while nside >= available_nside[0]:
+        if nside in available_nside:
+            #- Calculate uniq pixels only for targets not yet found
+            upix = hpix2upix(nside, hpix[not_found])
+
+            #- keep if this upix is indeed in the input upix
+            keep = is_in_sorted_array(upix, available_upix)
+
+            #- Update output array for whether this has been found
+            result_upix[not_found] = upix * keep  #- keep=False elements remain 0
+            not_found[not_found] = ~keep          #- not_found elements are now found
+
+        #- done with this nside, move to next smaller nside
+        nside = nside//2
+        hpix = hpix//4    #- much faster than recalculating radec2hpix
+
+    #- Return scalar or vector output depending upon ra/dec input
+    if scalar_input:
+        return result_upix[0]
+    else:
+        return result_upix
+
+

--- a/py/desiutil/test/test_healpix.py
+++ b/py/desiutil/test/test_healpix.py
@@ -1,0 +1,122 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desiutil.healpix.
+"""
+import unittest
+import numpy as np
+from ..healpix import radec2hpix, radec2upix, hpix2upix, upix2hpix
+from ..healpix import is_in_sorted_array
+from ..healpix import partition_radec, find_upix
+
+
+class TestHealpix(unittest.TestCase):
+    """Test desiutil.healpix
+    """
+
+    def test_radec2hpix(self):
+        """Test radec2hpix"""
+
+        # vector input
+        ra = np.arange(0,361,60)
+        dec = np.arange(-90,91,30)
+        assert len(ra) == len(dec)
+        hpix64 = radec2hpix(64, ra, dec)
+        hpix128 = radec2hpix(128, ra, dec)
+
+        self.assertListEqual(
+                list(hpix64),
+                [32768, 33255, 39769, 26282,  9382, 15896,  4095])
+        self.assertListEqual(list(hpix128//4), list(hpix64))
+
+        # scalar input
+        x = radec2hpix(64, ra[0], dec[0])
+        self.assertEqual(x, hpix64[0])
+
+    def test_radec2upix(self):
+        """Test radec2upix"""
+
+        # vector input
+        ra = np.arange(0,361,60)
+        dec = np.arange(-90,91,30)
+        assert len(ra) == len(dec)
+        hpix128 = radec2hpix(128, ra, dec)
+        upix128 = hpix128 + 4*128**2
+        self.assertListEqual(list(radec2upix(128, ra, dec)), list(upix128))
+        self.assertListEqual(list(radec2upix(64, ra, dec)), list(upix128//4))
+        self.assertListEqual(list(radec2upix(32, ra, dec)), list(upix128//16))
+
+        # scalar input
+        x = radec2upix(128, ra[1], dec[1])
+        self.assertEqual(x, upix128[1])
+
+    def test_upix_hpix(self):
+        """Test upix2hpix and hpix2upix"""
+        nside = np.array([16, 32, 64, 128])
+        hpix = np.array([1000, 2000, 3000, 4000])
+
+        # hpix -> upix
+        upix = hpix2upix(nside, hpix)
+        self.assertListEqual(list(upix), list(hpix + 4*nside**2))  # vector vector
+        self.assertEqual(hpix2upix(nside[0], hpix[0]), upix[0])    # scalar scalar
+        self.assertListEqual(list(hpix2upix(nside[0], hpix)), list(hpix + 4*nside[0]**2))  # scalar vector
+
+        # upix -> hpix
+        tmp_nside, tmp_hpix = upix2hpix(upix)
+        self.assertListEqual(list(tmp_nside), list(nside))
+        self.assertListEqual(list(tmp_hpix), list(hpix))
+        self.assertEqual(upix2hpix(upix[0]), (nside[0], hpix[0]))
+
+    def test_is_in_sorted_array(self):
+        """Test is_in_sorted_array"""
+        self.assertEqual(is_in_sorted_array(0, [1,2,5]), False)
+        self.assertEqual(is_in_sorted_array(1, [1,2,5]), True)
+        self.assertEqual(is_in_sorted_array(2, [1,2,5]), True)
+        self.assertEqual(is_in_sorted_array(3, [1,2,5]), False)
+        self.assertEqual(is_in_sorted_array(4, [1,2,5]), False)
+        self.assertEqual(is_in_sorted_array(5, [1,2,5]), True)
+        self.assertEqual(is_in_sorted_array(6, [1,2,5]), False)
+        self.assertListEqual(list(is_in_sorted_array([10,5,0,2,3], [1,2,5])),
+                             [False,True,False,True,False])
+
+    def test_partition_radec(self):
+        """test partition_radec and find_upix"""
+
+        # partition points into unique pixels
+        rand = np.random.RandomState(0)
+        n = 1000
+        nmax_per_healpix = 50
+        ra = rand.normal(180, 10, n)
+        dec = rand.normal(0, 10, n)
+        upix = partition_radec(ra, dec, nmax_per_healpix)
+        nside, hpix = upix2hpix(upix)
+
+        # confirm that we actually got different nside hierarchy
+        self.assertEqual(len(upix), n)
+        self.assertGreater(len(np.unique(nside)), 1)
+
+        # confirm that max(entries) < nmax_per_healpix
+        available_upix, counts = np.unique(upix, return_counts=True)
+        self.assertLessEqual(np.max(counts), nmax_per_healpix)
+
+        # Lookup ra,dec in available upix
+        upix2 = find_upix(ra, dec, available_upix)
+        self.assertTrue(np.all(upix2 == upix))
+        nside2, hpix2 = upix2hpix(upix2)
+        self.assertTrue(np.all(nside2 == nside))
+        self.assertTrue(np.all(hpix2 == hpix))
+        for this_nside in np.unique(nside):
+            ii = (nside == this_nside)
+            this_hpix = radec2hpix(this_nside, ra[ii], dec[ii])
+            self.assertTrue(np.all(this_hpix == hpix[ii]))
+
+        # Also works on scalars
+        single_upix = find_upix(ra[0], dec[0], available_upix)
+        self.assertEqual(single_upix, upix2[0])
+
+        # And even if available_upix isn't properly sorted
+        rand.shuffle(available_upix)
+        single_upix = find_upix(ra[0], dec[0], available_upix)
+        self.assertEqual(single_upix, upix2[0])
+        upix3 = find_upix(ra, dec, available_upix)
+        self.assertTrue(np.all(upix3 == upix))
+


### PR DESCRIPTION
This PR adds `desiutil.healpix` for working with healpix, including
  * mapping ra,dec to healpixels (hpix) and unique pixel identifiers (upix)
  * converting to/from nside,healpix and unique pixels
  * partitioning ra,dec arrays into unique pixels of varying nsides with a maximum number of elements each
  * finding which upix are covered by ra,dec given an array of potential available upix

These utilities are in the context of desiutil/desispec#2510, to provide a way to use adaptively sized nested healpix to handle varying densities on the sky.  They are provided here in desiutil to make them available to more packages without introducing dependency loops.

This includes tests with 100% coverage.

Note: `desiutil.healpix.radec2hpix` is redundant with `desimodel.footprint.radec2pix`, but this module provides additional functionality and a better dependency location.