### PR TITLE
Demonstrate simplified coverage tests and warning-as-error tests

### DIFF
--- a/.github/workflows/cron-warnings.yml
+++ b/.github/workflows/cron-warnings.yml
@@ -1,0 +1,59 @@
+# Workflow to catch warnings.
+name: Check for warnings (cron)
+
+on:
+    # The push option can be enabled for testing the workflow itself.
+    push:
+        branches:
+            - '*'
+    schedule:
+        # Friday, 22:00 UTC
+        - cron: '0 22 * * 5'
+
+
+jobs:
+    tests:
+        name: Unit tests
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    # Stable, yet close to bleeding-edge.
+                    - os: ubuntu-latest
+                      python-version: '3.13'
+                      numpy-version: '<3.0'
+                      astropy-version: '<8.0'
+                    - os: ubuntu-latest
+                      python-version: '3.12'
+                      numpy-version: '<2.2'
+                      astropy-version: '<7.1'
+                    - os: ubuntu-latest
+                      python-version: '3.11'
+                      numpy-version: '<2.1'
+                      astropy-version: '<7.1'
+                    - os: ubuntu-latest
+                      python-version: '3.10'
+                      numpy-version: '<2.0'
+                      astropy-version: '<7.0'
+                    # An environment similar to NERSC.
+                    - os: ubuntu-latest
+                      python-version: '3.10'
+                      numpy-version: '<1.23'
+                      astropy-version: '<6.1'
+
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v6
+          - name: Set up Python ${{ matrix.python-version }}
+            uses: actions/setup-python@v6
+            with:
+              python-version: ${{ matrix.python-version }}
+          - name: Install Python dependencies
+            run: |
+              python -m pip install --upgrade pip setuptools wheel
+              python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
+              python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
+              python -m pip install --editable .[test]
+          - name: Run the test, with warnings converted to errors
+            run: pytest -W error

--- a/.github/workflows/cron-warnings.yml
+++ b/.github/workflows/cron-warnings.yml
@@ -7,8 +7,8 @@ on:
     #     branches:
     #         - '*'
     schedule:
-        # Friday, 22:00 UTC
-        - cron: '0 22 * * 5'
+        # Monday, 12:00 UTC
+        - cron: '0 12 * * 1'
 
 
 jobs:

--- a/.github/workflows/cron-warnings.yml
+++ b/.github/workflows/cron-warnings.yml
@@ -3,9 +3,9 @@ name: Check for warnings (cron)
 
 on:
     # The push option can be enabled for testing the workflow itself.
-    push:
-        branches:
-            - '*'
+    # push:
+    #     branches:
+    #         - '*'
     schedule:
         # Friday, 22:00 UTC
         - cron: '0 22 * * 5'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,31 +20,40 @@ jobs:
         name: Unit tests
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: false  # reset to true after Astropy 7 issues are resolved.
+            fail-fast: true
             matrix:
                 include:
                     # Stable, yet close to bleeding-edge.
                     - os: ubuntu-latest
+                      coverage: false
                       python-version: '3.13'
                       numpy-version: '<3.0'
                       astropy-version: '<8.0'
                     - os: ubuntu-latest
+                      coverage: false
                       python-version: '3.12'
                       numpy-version: '<2.2'
                       astropy-version: '<7.1'
                     - os: ubuntu-latest
+                      coverage: false
                       python-version: '3.11'
                       numpy-version: '<2.1'
                       astropy-version: '<7.1'
-                    # Coverage test below creates an environment similar to NERSC.
                     - os: ubuntu-latest
+                      coverage: false
                       python-version: '3.10'
                       numpy-version: '<2.0'
                       astropy-version: '<7.0'
+                    # An environment similar to NERSC.
+                    - os: ubuntu-latest
+                      coverage: true
+                      python-version: '3.10'
+                      numpy-version: '<1.23'
+                      astropy-version: '<6.1'
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
               with:
@@ -54,41 +63,20 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
-                python -m pip install --editable .[test]
+            - name: Install the package itself
+              if: ${{ !fromJSON(matrix.coverage) }}
+              run: python -m pip install --editable .[test]
+            - name: Install the package itself, with coverage option
+              if: ${{ fromJSON(matrix.coverage) }}
+              run: python -m pip install --editable .[coverage]
             - name: Run the test
+              if: ${{ !fromJSON(matrix.coverage) }}
               run: pytest
-
-    coverage:
-        name: Test coverage
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os:
-                    - ubuntu-latest
-                python-version:
-                    - '3.10'
-                numpy-version:
-                    - '<1.23'
-                astropy-version:
-                    - '<6.1'
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v5
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v6
-              with:
-                python-version: ${{ matrix.python-version }}
-            - name: Install Python dependencies
-              run: |
-                python -m pip install --upgrade pip setuptools wheel
-                python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
-                python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
-                python -m pip install --editable .[coverage]
             - name: Run the test with coverage
+              if: ${{ fromJSON(matrix.coverage) }}
               run: pytest --cov
             - name: Coveralls
+              if: ${{ fromJSON(matrix.coverage) }}
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -107,7 +95,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
               with:
@@ -132,7 +120,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
               with:
@@ -159,7 +147,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
               with:
@@ -180,7 +168,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v6
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,28 +25,28 @@ jobs:
                 include:
                     # Stable, yet close to bleeding-edge.
                     - os: ubuntu-latest
-                      coverage: false
+                      coverage: test
                       python-version: '3.13'
                       numpy-version: '<3.0'
                       astropy-version: '<8.0'
                     - os: ubuntu-latest
-                      coverage: false
+                      coverage: test
                       python-version: '3.12'
                       numpy-version: '<2.2'
                       astropy-version: '<7.1'
                     - os: ubuntu-latest
-                      coverage: false
+                      coverage: test
                       python-version: '3.11'
                       numpy-version: '<2.1'
                       astropy-version: '<7.1'
                     - os: ubuntu-latest
-                      coverage: false
+                      coverage: test
                       python-version: '3.10'
                       numpy-version: '<2.0'
                       astropy-version: '<7.0'
                     # An environment similar to NERSC.
                     - os: ubuntu-latest
-                      coverage: true
+                      coverage: coverage
                       python-version: '3.10'
                       numpy-version: '<1.23'
                       astropy-version: '<6.1'
@@ -64,19 +64,11 @@ jobs:
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "numpy${{ matrix.numpy-version }}"
                 python -m pip install --upgrade --upgrade-strategy only-if-needed "astropy${{ matrix.astropy-version }}"
             - name: Install the package itself
-              if: ${{ !fromJSON(matrix.coverage) }}
-              run: python -m pip install --editable .[test]
-            - name: Install the package itself, with coverage option
-              if: ${{ fromJSON(matrix.coverage) }}
-              run: python -m pip install --editable .[coverage]
+              run: python -m pip install --editable .[${{ matrix.coverage }}]
             - name: Run the test
-              if: ${{ !fromJSON(matrix.coverage) }}
-              run: pytest
-            - name: Run the test with coverage
-              if: ${{ fromJSON(matrix.coverage) }}
-              run: pytest --cov
+              run: bash -c 'if [[ "${{ matrix.coverage }}" == "coverage" ]]; then pytest --cov; else pytest; fi'
             - name: Coveralls
-              if: ${{ fromJSON(matrix.coverage) }}
+              if: ${{ matrix.coverage == 'coverage' }}
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -167,7 +167,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: python -m pip install --upgrade pip setuptools wheel pycodestyle
-            - name: Test the style; failures are allowed
+            - name: Test the style
               # This is equivalent to an allowed falure.
               # continue-on-error: true
-              run: pycodestyle --count py/desiutil
+              run: pycodestyle --statistics --count py/desiutil

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,10 @@ Change Log
 3.6.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Merge coverage tests into the main test matrix; add cron tests for warnings
+  converted to errors (PR `#226`_).
+
+.. _`#226`: https://github.com/desihub/desiutil/pull/226
 
 3.6.0 (2025-12-03)
 ------------------

--- a/py/desiutil/iers.py
+++ b/py/desiutil/iers.py
@@ -12,9 +12,12 @@ high performance computing environment.
 The frozen files come from `astropy-iers-data 0.2023.6.15.21.10.12`_, which is
 the very first version, and thus closest in time to the start of the DESI survey.
 
-If even older files are desired, they can be obtained from the IERS archive.
+If even older files are desired, in principle, they could be derived from files
+available in the `IERS archive`_. However, this could also require a considerable
+investment of time.
 
 .. _`astropy-iers-data 0.2023.6.15.21.10.12`: https://pypi.org/project/astropy-iers-data/0.2023.6.15.21.10.12/
+.. _`IERS archive`: https://www.iers.org/IERS/EN/DataProducts/EarthOrientationData/eop
 """
 import os
 import warnings

--- a/py/desiutil/test/test_dust.py
+++ b/py/desiutil/test/test_dust.py
@@ -170,7 +170,8 @@ class TestDust(unittest.TestCase):
         # test scalar/vector combinations
         t = dust.mwdust_transmission(ebv, 'R', 'N')
         for i in range(len(t)):
-            self.assertEqual(t[i], dust.mwdust_transmission(ebv[i], 'R', 'N'))
+            # self.assertEqual(t[i], dust.mwdust_transmission(ebv[i], 'R', 'N'))
+            np.testing.assert_almost_equal(t[i], dust.mwdust_transmission(ebv[i], 'R', 'N'))
 
         tn = dust.mwdust_transmission(ebv, 'R', ['N']*len(ebv))
         ts = dust.mwdust_transmission(ebv, 'R', ['S']*len(ebv))

--- a/py/desiutil/test/test_funcfits.py
+++ b/py/desiutil/test/test_funcfits.py
@@ -3,8 +3,9 @@
 """Test desiutil.funcfits.
 """
 import unittest
+import pytest
 import numpy as np
-from warnings import catch_warnings, simplefilter
+from warnings import catch_warnings
 from ..funcfits import func_fit, func_val, iter_fit, mk_fit_dict
 
 
@@ -75,6 +76,8 @@ class TestFuncFits(unittest.TestCase):
         y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99941056289796115)
 
+    @pytest.mark.filterwarnings("ignore:The fit may be poorly conditioned")
+    @pytest.mark.filterwarnings("default")
     def test_func_fit_other(self):
         """Test corner cases in fitting.
         """
@@ -91,11 +94,7 @@ class TestFuncFits(unittest.TestCase):
             y2 = func_val(x2, dfit)
         x = np.array([1.0])
         y = np.array([2.0])
-        with catch_warnings(record=True) as w:
-            # simplefilter("always")
-            dfit = func_fit(x, y, 'polynomial', 1)
-            self.assertEqual(len(w), 1)
-            self.assertIn('conditioned', str(w[-1].message))
+        dfit = func_fit(x, y, 'polynomial', 1)
         self.assertEqual(dfit['xmin'], -1.0)
         self.assertEqual(dfit['xmax'], 1.0)
 
@@ -114,6 +113,8 @@ class TestFuncFits(unittest.TestCase):
         y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99941444872371643)
 
+    @pytest.mark.filterwarnings("ignore:Initial mask")
+    @pytest.mark.filterwarnings("default")
     def test_iterfit2(self):
         """Test iter fit with some special cases.
         """
@@ -123,13 +124,7 @@ class TestFuncFits(unittest.TestCase):
         #
         y[50] = 3.
         # Fit
-        with catch_warnings(record=True) as w:
-            # simplefilter("always")
-            dfit, mask = iter_fit(x, y, 'legendre', 4, forceimask=True)
-            self.assertEqual(len(w), 1)
-            self.assertEqual(str(w[-1].message),
-                             "Initial mask cannot be enforced -- " +
-                             "no initital mask supplied")
+        dfit, mask = iter_fit(x, y, 'legendre', 4, forceimask=True)
         x2 = np.linspace(0, np.pi, 100)
         y2 = func_val(x2, dfit)
         np.testing.assert_allclose(y2[50], 0.99941444872371643)

--- a/py/desiutil/test/test_funcfits.py
+++ b/py/desiutil/test/test_funcfits.py
@@ -5,7 +5,6 @@
 import unittest
 import pytest
 import numpy as np
-from warnings import catch_warnings
 from ..funcfits import func_fit, func_val, iter_fit, mk_fit_dict
 
 


### PR DESCRIPTION
This PR demonstrates:

* How to unify coverage tests with the other standard unit tests, thus simplifying the GitHub Actions tests.
* How to set up an Action that runs as a cron job, in this case to catch warnings by converting them to errors.

There are no changes to the user-facing code in this PR.