### PR TITLE
setuptools-scm support

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -17,10 +17,13 @@ Change Log
 3.6.1 (unreleased)
 ------------------
 
+* Support installing packages that use ``setuptools-scm`` to set version strings
+  (PR `#227`_)
 * Merge coverage tests into the main test matrix; add cron tests for warnings
   converted to errors (PR `#226`_).
 
 .. _`#226`: https://github.com/desihub/desiutil/pull/226
+.. _`#227`: https://github.com/desihub/desiutil/pull/227
 
 3.6.0 (2025-12-03)
 ------------------

--- a/doc/desiInstall.rst
+++ b/doc/desiInstall.rst
@@ -16,7 +16,7 @@ Basic Invocation of desiInstall
 
 :command:`desiInstall` is invoked with the product and version to be installed::
 
-    desiInstall desiutil 3.0.3
+    desiInstall desiutil 3.6.1
 
 The version should correspond to a tag in the repository corresponding to
 the product.
@@ -287,6 +287,12 @@ the environment variables :envvar:`WORKING_DIR` and :envvar:`INSTALL_DIR` exist.
 It will also set :envvar:`PRODUCT_VERSION`, where ``PRODUCT`` will be replaced
 by the actual name of the package, *e.g.*, :envvar:`DESIMODEL_VERSION`.
 
+For a few packages (speclite_, specsim_) that use setuptools-scm_ to dynamically
+set the version, a special environment variable, *e.g.*
+:envvar:`SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPECLITE`, is set to work around
+the fact that tarballs downloaded from GitHub do not contain the
+git metadata needed to construct the version string.
+
 Create site-packages
 --------------------
 
@@ -340,6 +346,18 @@ The script itself is intended to be a thin wrapper on *e.g.*::
 
 .. _fiberassign: https://github.com/desihub/fiberassign
 .. _specex: https://github.com/desihub/specex
+
+Set Version in Branch Installs
+------------------------------
+
+In a few cases (speclite_, specsim_) the version is set dynamically via
+setuptools-scm_. For branch installs, the version string needs to be constructed.
+Since branch installs *do* have the necessary git metadata to construct the version,
+a simple script is all that is needed.
+
+.. _speclite: https://github.com/desihub/speclite
+.. _specsim: https://github.com/desihub/specsim
+.. _setuptools-scm: https://setuptools-scm.readthedocs.io/
 
 Set Permissions
 ---------------

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -965,6 +965,11 @@ class DesiInstall(object):
         can be used to generate a version string, which can then be written to
         a version file.
 
+        In the event that this particular use of ``setup.py`` is finally deprecated,
+        ``setuptools-scm`` can and should be moved to the ``pyproject.toml`` file.
+
+        When installing a *tagged* version, this function does nothing.
+
         For tagged installs, :meth:`~desiutil.install.DesiInstall.prepare_environment`
         sets :envvar:`SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PACKAGE` with ``PACKAGE``
         replaced with the package name. This allows :command:`pip install` to

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -725,10 +725,11 @@ class DesiInstall(object):
                 mod = process_module(self.module_file, self.module_keywords,
                                      module_directory)
                 # Remove write permission to avoid accidental changes
-                outfile = os.path.join(module_directory,
-                                       self.module_keywords['name'],
-                                       self.module_keywords['version'])
-                # TODO: The snippet above doesn't do anything.
+                # outfile = os.path.join(module_directory,
+                #                        self.module_keywords['name'],
+                #                        self.module_keywords['version'])
+                # Permissions are handled by process_module(), so this
+                # shouldn't be needed.
             except OSError as ose:
                 self.log.critical(ose.strerror)
                 raise DesiInstallException(ose.strerror)

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -773,7 +773,7 @@ class DesiInstall(object):
         #
         # Set special env variable for setuptools-scm.
         #
-        if self.baseproduct in setuptools_scm_products:
+        if self.baseproduct in setuptools_scm_products and not self.is_branch:
             nov = self.baseversion
             if self.baseversion.startswith('v'):
                 nov = self.baseversion[1:]

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -836,7 +836,7 @@ class DesiInstall(object):
                 #            '--prefix={0}'.format(self.install_dir)]
                 command = [sys.executable, '-m', 'pip', 'install', '--no-deps',
                            '--disable-pip-version-check', '--ignore-installed',
-                           '--no-warn-script-location',
+                           '--no-warn-script-location', '--no-build-isolation',
                            '--prefix={0}'.format(self.install_dir), '.']
                 self.log.debug(' '.join(command))
                 if self.options.test:
@@ -949,6 +949,48 @@ class DesiInstall(object):
                         message = "Error compiling code: {0}".format(err)
                         self.log.critical(message)
                         raise DesiInstallException(message)
+        return
+
+    def compile_version(self):
+        """Generate a version string for main/branch installs of packages
+        that set the version string dynamically, *i.e.* with ``setuptools-scm``.
+        """
+        if self.is_branch and self.baseproduct in setuptools_scm_products:
+            current_dir = os.getcwd()
+            self.log.debug("os.chdir('%s')", self.install_dir)
+            os.chdir(self.install_dir)
+            setup_py = os.path.join(self.install_dir, 'setup.py')
+            if os.path.exists(setup_py):
+                version_template = None
+                version_command = [sys.executable, setup_py, '--version']
+            else:
+                version_template = """
+# Note that we need to fall back to the hard-coded version if either
+# setuptools_scm can't be imported or setuptools_scm can't determine the
+# version, so we catch the generic 'Exception'.
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+except Exception:
+    version = '{version}'
+""".lstrip()
+                version_command = [sys.executable, '-m', 'setuptools_scm']
+            proc = Popen(version_command, universal_newlines=True,
+                            stdout=PIPE, stderr=PIPE)
+            out, err = proc.communicate()
+            status = proc.returncode
+            self.log.debug(out)
+            if status != 0 and len(err) > 0:
+                message = "Error compiling version: {0}".format(err)
+                self.log.error(message)
+                self.log.error("Version string may need to be set manually!")
+            else:
+                if version_template is not None:
+                    with open(os.path.join(self.install_dir, self.baseproduct, 'version.py'), 'w') as VERSION:
+                        VERSION.write(version_template.format(version=out.split('+')[0]))
+            self.log.debug("os.chdir('%s')", current_dir)
+            os.chdir(current_dir)
+
         return
 
     def verify_bootstrap(self):

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -750,6 +750,7 @@ class DesiInstall(object):
         os.environ['WORKING_DIR'] = self.working_dir
         os.environ['INSTALL_DIR'] = self.install_dir
         if self.baseproduct == 'desiutil':
+            self.log.debug("os.environ['DESIUTIL'] = '%s'", self.install_dir)
             os.environ['DESIUTIL'] = self.install_dir
         else:
             if self.baseproduct in os.environ['LOADEDMODULES']:
@@ -765,6 +766,8 @@ class DesiInstall(object):
         # The current install script expects a version in the form of
         # branches/test-0.4 or tags/0.4.4 or trunk
         if env_version not in os.environ:
+            self.log.debug("os.environ['%s'] = 'tags/%s'",
+                           env_version, self.baseversion)
             os.environ[env_version] = 'tags/'+self.baseversion
         #
         # Set special env variable for setuptools-scm.
@@ -774,6 +777,7 @@ class DesiInstall(object):
             if self.baseversion.startswith('v'):
                 nov = self.baseversion[1:]
             scm_env = f"SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}"
+            self.log.debug("os.environ['%s'] = '%s'", scm_env, nov)
             os.environ[scm_env] = nov
         self.original_dir = os.getcwd()
         return self.original_dir

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -976,6 +976,7 @@ except Exception:
     version = '{version}'
 """.lstrip()
                 version_command = [sys.executable, '-m', 'setuptools_scm']
+            self.log.debug(' '.join(version_command))
             proc = Popen(version_command, universal_newlines=True,
                          stdout=PIPE, stderr=PIPE)
             out, err = proc.communicate()

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -976,7 +976,7 @@ except Exception:
 """.lstrip()
                 version_command = [sys.executable, '-m', 'setuptools_scm']
             proc = Popen(version_command, universal_newlines=True,
-                            stdout=PIPE, stderr=PIPE)
+                         stdout=PIPE, stderr=PIPE)
             out, err = proc.communicate()
             status = proc.returncode
             self.log.debug(out)

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -72,7 +72,10 @@ known_products = {
     'plate_layout': 'https://desi.lbl.gov/svn/code/focalplane/plate_layout',
     'positioner_control': 'https://desi.lbl.gov/svn/code/focalplane/positioner_control'}
 
-
+#
+# Packages that obtain their version strings dynamically via setuptools-scm.
+#
+setuptools_scm_products = ('speclite', 'specsim')
 #
 # Reserved for future use.
 #
@@ -627,7 +630,7 @@ class DesiInstall(object):
             ``True`` if the modules infrastructure was initialized
             successfully.
         """
-        initpy_found = False
+        # initpy_found = False
         module_method = init_modules(self.options.moduleshome, method=True)
         if module_method is None:
             message = ("Could not initialize Modules with MODULESHOME={0}!".format(
@@ -725,6 +728,7 @@ class DesiInstall(object):
                 outfile = os.path.join(module_directory,
                                        self.module_keywords['name'],
                                        self.module_keywords['version'])
+                # TODO: The snippet above doesn't do anything.
             except OSError as ose:
                 self.log.critical(ose.strerror)
                 raise DesiInstallException(ose.strerror)
@@ -733,7 +737,6 @@ class DesiInstall(object):
                                module_directory)
                 dot_version = default_module(self.module_keywords,
                                              module_directory)
-
         return mod
 
     def prepare_environment(self):
@@ -757,11 +760,21 @@ class DesiInstall(object):
                            self.baseproduct, self.baseversion)
             if not self.options.test:
                 self.module(m_command, self.baseproduct + '/' + self.baseversion)
-        env_version = self.baseproduct.upper() + '_VERSION'
+        env_product = self.baseproduct.upper().replace('-', '_')
+        env_version = env_product + '_VERSION'
         # The current install script expects a version in the form of
         # branches/test-0.4 or tags/0.4.4 or trunk
         if env_version not in os.environ:
             os.environ[env_version] = 'tags/'+self.baseversion
+        #
+        # Set special env variable for setuptools-scm.
+        #
+        if self.baseproduct in setuptools_scm_products:
+            nov = self.baseversion
+            if self.baseversion.startswith('v'):
+                nov = self.baseversion[1:]
+            scm_env = f"SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}"
+            os.environ[scm_env] = nov
         self.original_dir = os.getcwd()
         return self.original_dir
 

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -1114,6 +1114,7 @@ except Exception:
             self.install()
             self.get_extra()
             self.compile_branch()
+            self.compile_version()
             self.verify_bootstrap()
             self.permissions()
         except DesiInstallException:

--- a/py/desiutil/install.py
+++ b/py/desiutil/install.py
@@ -955,6 +955,21 @@ class DesiInstall(object):
     def compile_version(self):
         """Generate a version string for main/branch installs of packages
         that set the version string dynamically, *i.e.* with ``setuptools-scm``.
+
+        As of Spring 2026, only two DESI packages, ``speclite`` and ``specsim``,
+        use this method, and the configuration for ``setuptools-scm`` is stored
+        their ``setup.py`` files. :command:`python setup.py --version` will
+        create the necessary version file.
+
+        However, if there is no ``setup.py`` file, :command:`python -m setuptools_scm`
+        can be used to generate a version string, which can then be written to
+        a version file.
+
+        For tagged installs, :meth:`~desiutil.install.DesiInstall.prepare_environment`
+        sets :envvar:`SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PACKAGE` with ``PACKAGE``
+        replaced with the package name. This allows :command:`pip install` to
+        set the version, even though the GitHub tarballs do not contain
+        git metadata such as the last tag or commit ID.
         """
         if self.is_branch and self.baseproduct in setuptools_scm_products:
             current_dir = os.getcwd()

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -515,14 +515,16 @@ class TestInstall(unittest.TestCase):
             if product_name == 'specsim':
                 product_version = f"v{product_version}"
             env_product = product_name.upper().replace('-', '_')
-            with patch.dict('os.environ', {'NERSC_HOST': 'edison', 'DESICONDA': 'current'}):
+            with patch.dict('os.environ', {'NERSC_HOST': 'edison',
+                                           'DESICONDA': 'current',
+                                           'LOADEDMODULES': f"{product_name}/{product_version}"}):
                 options = self.desiInstall.get_options([product_name, product_version, '--test'])
                 self.desiInstall.get_product_version()
                 install_dir = self.desiInstall.set_install_dir()
                 self.desiInstall.working_dir = join(self.data_dir,
                                                     f"{product_name}-{product_version}")
                 self.assertEqual(install_dir, join(self.desiInstall.default_nersc_dir(),
-                                                'code', product_name, product_version))
+                                                   'code', product_name, product_version))
                 o_dir = self.desiInstall.prepare_environment()
                 self.assertEqual(environ[f'{env_product}_VERSION'], f'tags/{product_version}')
                 self.assertEqual(o_dir, self.desiInstall.original_dir)

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -529,8 +529,10 @@ class TestInstall(unittest.TestCase):
                 self.assertEqual(environ[f'{env_product}_VERSION'], f'tags/{product_version}')
                 self.assertEqual(o_dir, self.desiInstall.original_dir)
                 if product_name == 'specsim':
-                    self.assertEqual(environ['SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPECSIM'],
+                    self.assertEqual(environ[f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}'],
                                      product_version[1:])
+                else:
+                    self.assertNotIn(f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}', environ)
 
     def test_install(self):
         """Test the actuall installation process.

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -503,10 +503,26 @@ class TestInstall(unittest.TestCase):
         self.assertEqual(self.desiInstall.nersc_module_dir,
                          '/global/cfs/cdirs/desi/test/modulefiles')
 
-    def test_install_module(self):
+    @patch('desiutil.install.configure_module')
+    def test_install_module(self, mock_configure):
         """Test installation of module files.
         """
-        pass
+        product_name = 'specsim'
+        product_version = 'v1.0.0'
+        with patch.dict('os.environ', {'NERSC_HOST': 'edison',
+                                       'DESICONDA': 'current',
+                                       'LOADEDMODULES': f"{product_name}/{product_version}"}):
+            options = self.desiInstall.get_options([product_name, product_version, '--test'])
+            self.desiInstall.get_product_version()
+            install_dir = self.desiInstall.set_install_dir()
+            self.desiInstall.working_dir = join(self.data_dir,
+                                                f"{product_name}-{product_version}")
+            mod = self.desiInstall.install_module()
+            mock_configure.assert_called_once_with('specsim',
+                                                   'v1.0.0',
+                                                   join(self.desiInstall.options.root, 'code'),
+                                                   working_dir=self.desiInstall.working_dir,
+                                                   dev=False)
 
     def test_prepare_environment(self):
         """Test set up of build environment.
@@ -532,8 +548,13 @@ class TestInstall(unittest.TestCase):
                 if product_name == 'specsim':
                     self.assertEqual(environ[f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}'],
                                      product_version[1:])
+                    self.assertLog(-3, f"module('switch', '{product_name}/{product_version}')")
+                elif product_name == 'specprod-db':
+                    self.assertNotIn(f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}', environ)
+                    self.assertLog(-2, f"module('switch', '{product_name}/{product_version}')")
                 else:
                     self.assertNotIn(f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}', environ)
+
 
     def test_install(self):
         """Test the actuall installation process.

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -555,7 +555,6 @@ class TestInstall(unittest.TestCase):
                 else:
                     self.assertNotIn(f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}', environ)
 
-
     def test_install(self):
         """Test the actuall installation process.
         """

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 from unittest.mock import patch, call, MagicMock, mock_open
 from os import chdir, environ, getcwd, mkdir, remove, rmdir
-from os.path import abspath, basename, isdir, join
+from os.path import abspath, basename, isdir, isfile, join
 from shutil import rmtree
 from argparse import Namespace
 from tempfile import mkdtemp
@@ -604,6 +604,63 @@ class TestInstall(unittest.TestCase):
         message = "Error compiling code: err"
         self.assertLog(-1, message)
         self.assertEqual(str(cm.exception), message)
+
+    @patch('os.chdir')
+    @patch('os.path.exists')
+    @patch('desiutil.install.Popen')
+    def test_compile_version(self, mock_popen, mock_exists, mock_chdir):
+        """Test auto-generated version string.
+        """
+        current_dir = getcwd()
+        options = self.desiInstall.get_options(['specsim', 'branches/main'])
+        self.desiInstall.baseproduct = 'specsim'
+        self.desiInstall.is_branch = True
+        self.desiInstall.install_dir = join(self.data_dir, 'specsim')
+        if not isdir(self.desiInstall.install_dir):
+            mkdir(self.desiInstall.install_dir)
+            mkdir(join(self.data_dir, 'specsim', 'specsim'))
+        #
+        # Simulate a package that has setup.py.
+        #
+        mock_exists.return_value = True
+        mock_proc = mock_popen()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = ('1.0.1.dev6', 'err')
+        self.desiInstall.compile_version()
+        mock_exists.assert_has_calls([call(join(self.desiInstall.install_dir, 'setup.py'))])
+        mock_chdir.assert_has_calls([call(self.desiInstall.install_dir),
+                                     call(current_dir)])
+        mock_popen.assert_has_calls([call(),
+                                     call([sys.executable,
+                                           join(self.desiInstall.install_dir, 'setup.py'),
+                                           '--version'],
+                                          stderr=-1, stdout=-1, universal_newlines=True),
+                                     call().communicate()])
+        #
+        # Simulate a package that does not have setup.py
+        #
+        mock_exists.return_value = False
+        mock_proc = mock_popen()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = ('1.0.1.dev6+g329b1f2', 'err')
+        self.desiInstall.compile_version()
+        mock_exists.assert_has_calls([call(join(self.desiInstall.install_dir, 'setup.py'))])
+        mock_chdir.assert_has_calls([call(self.desiInstall.install_dir),
+                                     call(current_dir)])
+        mock_popen.assert_has_calls([call([sys.executable, '-m', 'setuptools_scm'],
+                                          stderr=-1, stdout=-1, universal_newlines=True)], any_order=True)
+        self.assertTrue(isfile(join(self.desiInstall.install_dir, 'specsim', 'version.py')))
+        #
+        # Simulate an error condition when attempting to set the version.
+        #
+        mock_exists.return_value = False
+        mock_proc = mock_popen()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = ('', 'err')
+        self.desiInstall.compile_version()
+        message = "Error compiling version: err"
+        self.assertLog(-3, message)
+        self.assertLog(-2, "Version string may need to be set manually!")
 
     def test_verify_bootstrap(self):
         """Test proper installation of the desiInstall executable.

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -510,7 +510,25 @@ class TestInstall(unittest.TestCase):
     def test_prepare_environment(self):
         """Test set up of build environment.
         """
-        pass
+        for product_name in ('desiutil', 'specprod-db', 'specsim'):
+            product_version = '3.6.0'
+            if product_name == 'specsim':
+                product_version = f"v{product_version}"
+            env_product = product_name.upper().replace('-', '_')
+            with patch.dict('os.environ', {'NERSC_HOST': 'edison', 'DESICONDA': 'current'}):
+                options = self.desiInstall.get_options([product_name, product_version, '--test'])
+                self.desiInstall.get_product_version()
+                install_dir = self.desiInstall.set_install_dir()
+                self.desiInstall.working_dir = join(self.data_dir,
+                                                    f"{product_name}-{product_version}")
+                self.assertEqual(install_dir, join(self.desiInstall.default_nersc_dir(),
+                                                'code', product_name, product_version))
+                o_dir = self.desiInstall.prepare_environment()
+                self.assertEqual(environ[f'{env_product}_VERSION'], f'tags/{product_version}')
+                self.assertEqual(o_dir, self.desiInstall.original_dir)
+                if product_name == 'specsim':
+                    self.assertEqual(environ['SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPECSIM'],
+                                     product_version[1:])
 
     def test_install(self):
         """Test the actuall installation process.

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -538,6 +538,7 @@ class TestInstall(unittest.TestCase):
                 options = self.desiInstall.get_options([product_name, product_version, '--test'])
                 self.desiInstall.get_product_version()
                 install_dir = self.desiInstall.set_install_dir()
+                self.desiInstall.is_branch = False
                 self.desiInstall.working_dir = join(self.data_dir,
                                                     f"{product_name}-{product_version}")
                 self.assertEqual(install_dir, join(self.desiInstall.default_nersc_dir(),

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -434,9 +434,8 @@ class TestInstall(unittest.TestCase):
                              self.desiInstall.default_nersc_dir(), 'code',
                              'desiutil', test_code_version))
 
-    @unittest.skipUnless('MODULESHOME' in environ,
-                         'Skipping because MODULESHOME is not defined.')
-    def test_start_modules(self):
+    @patch('desiutil.modules.which')
+    def test_start_modules(self, mock_which):
         """Test the initialization of the Modules environment.
         """
         options = self.desiInstall.get_options(['-m',
@@ -447,10 +446,12 @@ class TestInstall(unittest.TestCase):
         self.assertEqual(str(cm.exception), ("Could not initialize Modules " +
                          "with MODULESHOME={0}!").format(
                          '/fake/modules/directory'))
-        options = self.desiInstall.get_options(['desiutil', 'branches/main'])
-        self.assertEqual(options.moduleshome, environ['MODULESHOME'])
-        status = self.desiInstall.start_modules()
-        self.assertTrue(callable(self.desiInstall.module))
+        mock_which.return_value = True
+        with patch.dict('os.environ', {'MODULESHOME': self.data_dir}):
+            options = self.desiInstall.get_options(['desiutil', 'branches/main'])
+            self.assertEqual(options.moduleshome, environ['MODULESHOME'])
+            status = self.desiInstall.start_modules()
+            self.assertTrue(callable(self.desiInstall.module))
 
     @patch('desiutil.install.dependencies')
     @patch('os.path.exists')

--- a/py/desiutil/test/test_install.py
+++ b/py/desiutil/test/test_install.py
@@ -556,8 +556,18 @@ class TestInstall(unittest.TestCase):
                 else:
                     self.assertNotIn(f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{env_product}', environ)
 
-    def test_install(self):
-        """Test the actuall installation process.
+    def test_install_plain(self):
+        """Test the installation process for plain or branch installs.
+        """
+        pass
+
+    def test_install_py(self):
+        """Test the installation process for build_type 'py'.
+        """
+        pass
+
+    def test_install_make(self):
+        """Test the installation process for build_type 'make'/'src'.
         """
         pass
 


### PR DESCRIPTION
This PR adds support for products that get their version via `setuptools-scm`. Currently these are `speclite` and `specsim`. For installs of tagged versions, the environment variable `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPEC(LITE|SIM)` is set.

For main/branch installs, the exact method remains TBD, so this is starting out as a draft PR.

In addition, some debug statements and unit tests are added.